### PR TITLE
Rewrite semantics

### DIFF
--- a/docs/smol.md
+++ b/docs/smol.md
@@ -570,8 +570,8 @@ out, it does not need to be handled:
 		static handle(x Three) Unit
 		requires (x isa c).not() {
 			match x {
-				case a a {}
-				case b b {}
+				case a is a {}
+				case b is b {}
 				// OK with no c case
 			}
 		}

--- a/src/codegen/genc.lua
+++ b/src/codegen/genc.lua
@@ -658,7 +658,7 @@ local function generateStatement(statement, program, info)
 		local lhs = localName(statement.destination.name)
 		local rhs = "ALLOCATE(smol_Boolean_T)"
 		program:assign(lhs, rhs)
-		program:assign(lhs .. "->value", statement.boolean and 1 or 0)
+		program:assign(lhs .. "->value", statement.boolean and "1" or "0")
 		return
 	elseif statement.tag == "field" then
 		local lhs = localName(statement.destination.name)

--- a/src/codegen/genc.lua
+++ b/src/codegen/genc.lua
@@ -1,4 +1,4 @@
--- Curtis Fenner, copyright (C) 2017
+local common = import "common.lua"
 
 local BUILTIN_NAME_MAP = {
 	Int = true,
@@ -8,10 +8,335 @@ local BUILTIN_NAME_MAP = {
 	Never = true,
 }
 
+--------------------------------------------------------------------------------
+
+local FOREIGN_IMPLEMENTATION = {}
+
+FOREIGN_IMPLEMENTATION["core:ASCII.formatInt"] = [[
+	smol_String_T* out1;
+	out1 = ALLOCATE(smol_String_T);
+	out1->text = ALLOCATE_ARRAY(32, char);
+	out1->length = (size_t)sprintf(out1->text, "%" PRId64, smol_local_value->value);
+]]
+
+FOREIGN_IMPLEMENTATION["core:Out.println"] = [[
+	// TODO: allow nulls, etc.
+	for (size_t i = 0; i < smol_local_message->length; i++) {
+		putchar(smol_local_message->text[i]);
+	}
+	printf("\n");
+	smol_Unit_T* out1 = NULL;
+]]
+
+FOREIGN_IMPLEMENTATION["String:concatenate"] = [[
+	smol_String_T* out1 = ALLOCATE(smol_String_T);
+	out1->length = smol_local_left->length + smol_local_right->length;
+	out1->text = ALLOCATE_ARRAY(out1->length, char);
+	for (size_t i = 0; i < smol_local_left->length; i++) {
+		out1->text[i] = smol_local_left->text[i];
+	}
+	for (size_t i = 0; i < smol_local_right->length; i++) {
+		out1->text[i + smol_local_left->length] = smol_local_right->text[i];
+	}
+]]
+
+FOREIGN_IMPLEMENTATION["String:eq"] = [[
+	smol_Boolean_T* out1 = ALLOCATE(smol_Boolean_T);
+	size_t length = smol_local_left->length;
+	if (length != smol_local_right->length) {
+		out1->value = 0;
+	} else {
+		out1->value = 0 == memcmp(smol_local_left->text, smol_local_right->text, length);
+	}
+]]
+
+FOREIGN_IMPLEMENTATION["Boolean:implies"] = [[
+	smol_Boolean_T* out1 = ALLOCATE(smol_Boolean_T);
+	out1->value = !smol_local_left->value || smol_local_right->value;
+]]
+
+FOREIGN_IMPLEMENTATION["Boolean:not"] = [[
+	smol_Boolean_T* out1 = ALLOCATE(smol_Boolean_T);
+	out1->value = !smol_local_left->value;
+]]
+
+FOREIGN_IMPLEMENTATION["Boolean:eq"] = [[
+	smol_Boolean_T* out1 = ALLOCATE(smol_Boolean_T);
+	out1->value = (!smol_local_left->value) == (!smol_local_right->value);
+]]
+
+FOREIGN_IMPLEMENTATION["Boolean:and"] = [[
+	smol_Boolean_T* out1 = ALLOCATE(smol_Boolean_T);
+	out1->value = smol_local_left->value && smol_local_right->value;
+]]
+
+FOREIGN_IMPLEMENTATION["Boolean:or"] = [[
+	smol_Boolean_T* out1 = ALLOCATE(smol_Boolean_T);
+	out1->value = smol_local_left->value || smol_local_right->value;
+]]
+
+FOREIGN_IMPLEMENTATION["Int:difference"] = [[
+	smol_Int_T* out1 = ALLOCATE(smol_Int_T);
+	out1->value = smol_local_arg1->value - smol_local_arg2->value;
+]]
+
+FOREIGN_IMPLEMENTATION["Int:sum"] = [[
+	smol_Int_T* out1 = ALLOCATE(smol_Int_T);
+	out1->value = smol_local_arg1->value + smol_local_arg2->value;
+]]
+
+FOREIGN_IMPLEMENTATION["Int:product"] = [[
+	smol_Int_T* out1 = ALLOCATE(smol_Int_T);
+	out1->value = smol_local_arg1->value * smol_local_arg2->value;
+]]
+
+FOREIGN_IMPLEMENTATION["Int:quotient"] = [[
+	smol_Int_T* out1 = ALLOCATE(smol_Int_T);
+	out1->value = smol_local_arg1->value / smol_local_arg2->value;
+]]
+
+FOREIGN_IMPLEMENTATION["Int:negate"] = [[
+	smol_Int_T* out1 = ALLOCATE(smol_Int_T);
+	out1->value = -smol_local_arg1->value;
+]]
+
+FOREIGN_IMPLEMENTATION["Int:lessThan"] = [[
+	smol_Boolean_T* out1 = ALLOCATE(smol_Boolean_T);
+	out1->value = smol_local_arg1->value < smol_local_arg2->value;
+]]
+
+FOREIGN_IMPLEMENTATION["Int:eq"] = [[
+	smol_Boolean_T* out1 = ALLOCATE(smol_Boolean_T);
+	out1->value = smol_local_arg1->value == smol_local_arg2->value;
+]]
+
+FOREIGN_IMPLEMENTATION["Int:isPositive"] = [[
+	smol_Boolean_T* out1 = ALLOCATE(smol_Boolean_T);
+	out1->value = 0 < smol_local_arg1->value;
+]]
+
+--------------------------------------------------------------------------------
+
+-- Represents a source file
+local Program = {}
+Program.__index = Program
+
+-- RETURNS a blank program
+function Program.new(indent)
+	local instance = {
+		_chunks = {},
+		_indent = indent or 0,
+	}
+	return setmetatable(instance, Program)
+end
+
+-- Appends a line of text to the end of this progra
+-- RETURNS nothing
+-- MODIFIES this
+function Program:write(text)
+	assert(type(text) == "string")
+	table.insert(self._chunks, string.rep("\t", self._indent) .. text)
+end
+
+-- RETURNS a Program representing a chunk appended to the end of the file
+-- MODIFIES this
+function Program:section(indent)
+	local c = Program.new(self._indent + (indent or 0))
+	table.insert(self._chunks, c)
+	return c
+end
+
+-- RETURNS a string representing all of the lines of this program
+function Program:serialize()
+	local seq = {}
+	for i = 1, #self._chunks do
+		if type(self._chunks[i]) == "string" then
+			seq[i] = self._chunks[i]
+		else
+			seq[i] = self._chunks[i]:serialize()
+		end
+	end
+	return table.concat(seq, "\n")
+end
+
+--------------------------------------------------------------------------------
+
+-- Represents a C source file
+local CProgram = {}
+CProgram.__index = CProgram
+
+-- RETURNS a blank C program
+function CProgram.new()
+	local instance = {
+		_program = Program.new(),
+	}
+
+	-- Initialize root information
+	instance._tupleMap = {}
+
+	instance.preamble = instance._program:section()
+
+	instance._forward = instance._program:section()
+	instance._forward:write("// FORWARD DECLARATIONS")
+
+	instance._definitions = instance._program:section()
+	instance._definitions:write("// DECLARATION BODIES")
+
+	instance._prototypes = instance._program:section()
+	instance._prototypes:write("// FUNCTION PROTOTYPES")
+
+	instance._functions = instance._program:section()
+	instance._functions:write("// FUNCTION IMPLEMENTATIONS")
+
+	instance._root = instance
+
+	return setmetatable(instance, CProgram)
+end
+
+-- RETURNS this program's text as a string
+function CProgram:serialize()
+	return self._program:serialize()
+end
+
+-- RETURNS nothing
+-- MODIFIES this program
+function CProgram:defineStruct(name, fields)
+	if self ~= self._root then
+		return self._root:defineStruct(name, fields)
+	end
+
+	assertis(fields, listType(recordType {
+		name = "string",
+		type = "string",
+	}))
+	assert(1 <= #fields)
+
+	self._forward:write("typedef struct " .. name .. "_struct " .. name .. ";")
+	self._definitions:write("struct " .. name .. "_struct {")
+	for _, field in ipairs(fields) do
+		self._definitions:write("\t" .. field.type .. " " .. field.name .. ";")
+	end
+	self._definitions:write("};")
+	self._definitions:write("")
+end
+
+-- RETURNS a string representing a (one word) C type with fields 
+-- _1, _2, ..., _{#fields}
+-- of the given C types
+-- REQUIRES at least one field is given
+function CProgram:getTuple(fields)
+	if self ~= self._root then
+		return self._root:getTuple(fields)
+	end
+
+	assertis(fields, listType "string")
+	assert(1 <= #fields, "cannot make a tuple for zero fields")
+
+	local id = table.concat(fields, ", ")
+	assert(not id:find("\n"))
+	if self._tupleMap[id] then
+		return self._tupleMap[id]
+	end
+
+	-- Generate a unique name
+	local name = "_tuple_" .. #table.keys(self._tupleMap) .. "_T"
+	self._tupleMap[id] = name
+
+	-- Create forward declaration
+	self._forward:write("// tuple (" .. id .. ")")
+	self._forward:write("typedef struct " .. name .. "_struct " .. name .. ";")
+	self._forward:write("")
+
+	-- Give definition
+	self._definitions:write("struct " .. name .. "_struct {")
+	for i = 1, #fields do
+		self._definitions:write("\t" .. fields[i] .. " _" .. i .. ";")
+	end
+	self._definitions:write("};")
+	self._definitions:write("")
+
+	return name
+end
+
+-- RETURNS a C program section
+-- MODIFIES this
+function CProgram:defineFunction(name, returns, parameters)
+	if self ~= self._root then
+		return self._root:getTuple(name, returns, parameters)
+	end
+
+	assertis(name, "string")
+	assertis(returns, "string")
+	assertis(parameters, listType(recordType {
+		type = "string",
+		name = "string",
+	}))
+
+	local ps = {}
+	for _, p in ipairs(parameters) do
+		table.insert(ps, p.type .. " " .. p.name)
+	end
+	
+	local prototype = returns .. " " .. name .. "(" .. table.concat(ps, ", ") .. ")"
+
+	self._prototypes:write(prototype .. ";")
+
+	local fn = self._functions:section(0)
+	fn:write(prototype .. " {")
+	local body = fn:section(1)
+	fn:write("}")
+	fn:write("")
+
+	local out = {
+		_program = body,
+		_root = self._root,
+	}
+
+	return setmetatable(out, CProgram)
+end
+
+-- RETURNS a subsection of this program
+-- MODIFIES this
+function CProgram:section(indent)
+	local s = self._program:section(indent)
+
+	local out = {
+		_program = s,
+		_root = self._root,
+	}
+	return setmetatable(out, CProgram)
+end
+
+-- RETURNS nothing
+-- TODO: get rid of this function so that all writing is structure
+function CProgram:write(text)
+	self._program:write(text)
+end
+
+-- Appends a comment to the program
+-- RETURNS nothing
+-- MODIFIES this
+function CProgram:comment(text)
+	assert(not text:find("\n"), "TODO: comment with newlines")
+
+	self:write("// " .. text)
+end
+
+-- Appends an assignment to the program
+-- RETURNS nothing
+-- MODIFIES this
+function CProgram:assign(lhs, rhs)
+	assert(type(lhs) == "string")
+	assert(type(rhs) == "string", type(rhs))
+
+	self:write(lhs .. " = " .. rhs .. ";")
+end
+
+--------------------------------------------------------------------------------
+
 -- RETURNS a string
 local function luaizeName(name)
-	assert(not name:find "%.")
-	return name:gsub(":", "_"):gsub("#", "hash")
+	return name:gsub("[:.]", "_"):gsub("#", "hash_")
 end
 
 -- RETURNS a string
@@ -21,39 +346,7 @@ local function staticFunctionName(longName)
 	return "smol_static_" .. luaizeName(longName)
 end
 
--- RETURNS a string
-local function methodFunctionName(longName)
-	assertis(longName, "string")
-	assert(longName:find ":")
-
-	return "smol_method_" .. luaizeName(longName)
-end
-
--- RETURNS a string
-local function concreteConstraintFunctionName(definitionName, interfaceName)
-	return "smol_concrete_constraint_" .. luaizeName(definitionName) .. "_for_" .. luaizeName(interfaceName)
-end
-
--- RETURNS a string of smol representing the given type
-local function showType(t)
-	assertis(t, "Type+")
-
-	if t.tag == "concrete-type+" then
-		if #t.arguments == 0 then
-			return t.name
-		end
-		local arguments = table.map(showType, t.arguments)
-		return t.name .. "[" .. table.concat(arguments, ", ") .. "]"
-	elseif t.tag == "keyword-type+" then
-		return t.name
-	elseif t.tag == "generic+" then
-		return "#" .. t.name
-	end
-	error("unknown Type+ tag `" .. t.tag .. "`")
-end
-
-local C_THIS_LOCAL = "this"
-local C_CONSTRAINT_PARAMETER_PREFIX = "cons"
+local CONSTRAINT_PARAMETER = "cons"
 local TAG_FIELD = "tag"
 
 -- RETURNS a string representing a C identifier for a Smol variable or parameter
@@ -78,50 +371,21 @@ local function unionFieldName(name)
 	return "smol_case_" .. name
 end
 
--- RETURNS a string representing a C type
-local function cType(t, scope)
-	assertis(t, "Type+")
-	assertis(scope, mapType("string", "string"))
+-- RETURNS a C type name
+local function compoundStructName(name)
+	assertis(name, "string")
 
-	if t.tag == "generic+" or t.tag == "self-type+" then
-		return "void*"
-	elseif t.tag == "concrete-type+" then
-		return scope[t.name] .. "*"
-	elseif t.tag == "keyword-type+" then
-		return "smol_" .. t.name .. "*"
+	if BUILTIN_NAME_MAP[name] then
+		return "smol_" .. name .. "_T"
 	end
-	error "unknown"
-end
+	assert(name:find(":"))
 
--- RETURNS a string representing a tuple type
--- (even for 1 tuples, which may be inefficient, but is uniform)
-local function cTypeTuple(ts, demandTuple, scope)
-	assertis(ts, listType "Type+")
-	assertis(demandTuple, "function")
-	assert(#ts >= 1)
-	assertis(scope, mapType("string", "string"))
-
-	local shown = table.map(cType, ts, scope)
-	return demandTuple(shown)
+	return "smol_compound_" .. name:gsub(":", "_") .. "_T"
 end
 
 -- RETURNS a string
 local function commented(message)
 	return "// " .. message:gsub("\n", "\n// ")
-end
-
--- RETURNS a string of C-code representing a literal to use as
--- the tag value for a union object
-local function unionTagValue(union, variant)
-	assertis(union, "UnionIR")
-	assertis(variant, "string")
-
-	for i, field in ipairs(union.fields) do
-		if field.name == variant then
-			return tostring(i)
-		end
-	end
-	error("no variant")
 end
 
 -- RETURNS a string
@@ -144,17 +408,34 @@ local function cEncodedString(value)
 end
 
 -- RETURNS a string
-local function luaEncodedNumber(value)
+local function cEncodedNumber(value)
 	assertis(value, "number")
 
-	return tostring(value)
+	return string.format("%d", value)
 end
 
-local function indentedEmitter(emit)
-	assertis(emit, "function")
+-- RETURNS a C type string for the given smol type
+-- When noPointer, get the underlying struct type
+-- Otherwise, a pointer to the underlying struct type
+local function cType(t, noPointer)
+	assertis(t, "TypeKind")
 
-	return function(line)
-		return emit("\t" .. line)
+	if t.tag == "compound-type" then
+		-- Note that it does not distinguish by type parameters
+		local base = compoundStructName(t.packageName .. ":" .. t.definitionName)
+		if noPointer then
+			return base
+		end
+		return base .. "*"
+	elseif t.tag == "generic-type" or t.tag == "self-type" then
+		assert(not noPointer)
+		return "void*"
+	elseif t.tag == "keyword-type" then
+		local base = compoundStructName(t.name)
+		if noPointer then
+			return base
+		end
+		return base .. "*"
 	end
 end
 
@@ -166,424 +447,240 @@ local function interfaceStructName(name)
 	return "smol_interface_" .. name:gsub(":", "_") .. "_T"
 end
 
--- RETURNS a C type name
-local function classStructName(name)
+-- RETURNS a C identifier
+local function vtableMemberName(name)
 	assertis(name, "string")
+	assert(not name:find("[:.]"))
 
-	if BUILTIN_NAME_MAP[name] then
-		return "smol_" .. name
+	return "d_smol_" .. name
+end
+
+-- RETURNS a C type string
+local function cVTableType(c)
+	assertis(c, "ConstraintKind")
+
+	if c.tag == "interface-constraint" then
+		return interfaceStructName(c.packageName .. ":" .. c.definitionName)
 	end
-	assert(name:find(":"))
-
-	return "smol_class_" .. name:gsub(":", "_") .. "_T"
+	error("TODO")
 end
 
--- RETURNS a C type name
-local function unionStructName(name)
-	assertis(name, "string")
-	assert(name:find(":"))
+local _counter = 0
 
-	return "smol_union_" .. name:gsub(":", "_") .. "_T"
+-- RETURNS a unique temporary variable name
+local function uniqueTmp()
+	_counter = _counter + 1
+	return "_tmp" .. _counter
 end
 
--- RETURNS a string representing a C type
-local function cDefinitionType(definition)
-	if definition.tag == "class" then
-		return classStructName(definition.name) .. "*"
-	elseif definition.tag == "union" then
-		return unionStructName(definition.name) .. "*"
-	elseif definition.tag == "builtin" then
-		return "smol_" .. definition.name .. "*"
-	end
-	error("unknown definition tag `" .. definition.tag .. "`")
-end
+-- RETURNS name, type as strings
+-- MODIFIES program
+local function generateVTable(a, program, info)
+	assertis(a, "VTableIR")
+	assertis(program, "object")
+	assertis(info, recordType {
+		constraints = mapType("string", recordType {
+			members = listType("string"),
+		}),
+		parameterIndices = mapType("string", "integer"),
+	})
 
--- RETURNS a C struct field identifier
--- name must be a constraint "name", e.g., "2_3"
-local function structConstraintField(name)
-	assert(name:match("^#%d+_%d+$"))
+	if a.tag == "parameter-vtable" then
+		local tmp = uniqueTmp() .. "_vtable"
+		local tmpType = cVTableType(a.interface)
+		local i = info.parameterIndices[a.name]
+		program:assign(tmpType .. " " .. tmp, CONSTRAINT_PARAMETER .. "->_" .. i)
+		return tmp, tmpType
+	elseif a.tag == "concrete-vtable" then
+		local tmp = uniqueTmp() .. "_vtable"
+		local tmpType = cVTableType(a.interface)
 
-	return "constraint_" .. name:sub(2)
-end
+		error "TODO: collect arguments to pass to closure building"
+		error "TODO: get list of all members to make closures of"
 
--- RETURNS a string that is a Lua expression
-local function cConstraint(constraint, semantics)
-	assertis(constraint, "ConstraintIR")
-	assertis(semantics, "Semantics")
-
-	if constraint.tag == "parameter-constraint" then
-		-- XXX
-		return C_CONSTRAINT_PARAMETER_PREFIX .. "_" .. constraint.name:gsub("#", "")
-	elseif constraint.tag == "concrete-constraint" then
-		local func = concreteConstraintFunctionName(constraint.concrete.name, constraint.interface.name)
-		local definition = table.findwith(semantics.compounds, "name", constraint.concrete.name)
-		assertis(definition, recordType {generics = listType "TypeParameterIR"})
-
-		local argumentValues = {}
-		for i, generic in ipairs(definition.generics) do
-			for j, c in ipairs(generic.constraints) do
-				-- XXX
-				local key = "#" .. i .. "_" .. j
-				local assignment = constraint.assignments[key]
-				table.insert(argumentValues, cConstraint(assignment, semantics))
-			end
+		for name in pairs(interface.functionMap) do
+			local closureName = uniqueTmp() .. "_closure"
+			local closureType = "CLOSURE_TYPE(" .. rt .. ", " .. table.concat(pt, ", ") .. ")"
+			local needed = error "TODO: collect arguments to pass to closure"
+			local fptr = staticFunctionName(a.concrete.packageName .. ":" .. a.concrete.definitionName .. "." .. name)
+			program:assign(closureType .. " " .. closureName, "(" .. closureType .. "){" .. needed .. ", " .. fptr .. "}")
+			program:assign(tmp .. "." .. vtableMemberName(name), closure)
 		end
-
-		local arguments = table.concat(argumentValues, ", ")
-		return func .. "(" .. arguments .. ")"
-	elseif constraint.tag == "this-constraint" then
-		return localName(constraint.instance.name) .. "->" .. structConstraintField(constraint.name)
 	end
-	error("unimplemented constraint tag `" .. constraint.tag .. "`")
-end
-
--- RETURNS a string representing a interface struct field name
-local function interfaceMember(name)
-	return "i_" .. luaizeName(name)
-end
-
--- REQUIRES that demandTuple has already been called; otherwise the referenced
--- tuple type doesn't exist
--- RETURNS a string that is a C type name
-local function preTupleName(list)
-	assert(list, listType "string")
-
-	-- TODO: deal with 0-tuples
-	local values = {}
-	for _, element in ipairs(list) do
-		table.insert(values, (element:gsub("%*", "_ptr")))
-		assert(not element:find("%s"))
-	end
-	local name = "tuple" .. #list
-	for i, value in ipairs(values) do
-		name = name .. "_" .. i .. "_" .. value
-	end
-
-	return name
-end
-
--- RETURNS a C function identifier
-local function cWrapperName(signature, class, interface)
-	return "wrapper_" .. luaizeName(class) .. "_" .. luaizeName(signature) .. "_is_" .. luaizeName(interface)
-end
-
-local counter = 0
-local function UID()
-	counter = counter + 1
-	return counter
+	error("unknown VTableIR tag `" .. a.tag .. "`")
 end
 
 -- RETURNS nothing
--- Appends strings to code
-local function generateStatement(statement, emit, structScope, semantics, demandTuple)
+-- MODIFIES program to include C statements executing the given statement
+local function generateStatement(statement, program, info)
 	assertis(statement, "StatementIR")
-	assertis(structScope, mapType("string", "string"))
-	assertis(demandTuple, "function")
-	statement = freeze(statement)
+	assertis(program, "object")
+	assertis(info, recordType {
+		constraints = mapType("string", recordType {
+			members = listType("string"),
+		}),
+		unions = mapType("string", recordType {
+			tags = mapType("string", "integer"),
+		}),
+	})
 
-	if statement.tag == "block" then
-		for _, subStatement in ipairs(statement.statements) do
-			generateStatement(subStatement, emit, structScope, semantics, demandTuple)
+	program:comment(statement.tag)
+
+	if statement.tag == "proof" then
+		program:comment("skipping proof")
+		return
+	elseif statement.tag == "sequence" then
+		for _, s in ipairs(statement.statements) do
+			generateStatement(s, program, info)
 		end
 		return
-	end
-
-	-- Emits a comment
-	local function comment(message)
-		emit("// " .. message)
-	end
-
-	-- Plain statements
-	if statement.tag == "local" then
-		comment("var " .. statement.variable.name .. " " .. showType(statement.variable.type) .. ";")
-		emit(cType(statement.variable.type, structScope) .. " " .. localName(statement.variable.name) .. ";")
+	elseif statement.tag == "string-load" then
+		local lhs = localName(statement.destination.name)
+		local rhs = "ALLOCATE(smol_String_T)"
+		program:assign(lhs, rhs)
+		program:assign(lhs .. "->length", tostring(#statement.string))
+		program:assign(lhs .. "->text", cEncodedString(statement.string))
 		return
-	elseif statement.tag == "string" then
-		comment(statement.destination.name .. " = " .. cEncodedString(statement.string) .. ";")
-		local name = localName(statement.destination.name)
-		emit(name .. " = ALLOCATE(smol_String);")
-		emit(name .. "->length = " .. #statement.string .. ";")
-		emit(name .. "->text = " .. cEncodedString(statement.string) .. ";")
+	elseif statement.tag == "local" then
+		program:write(cType(statement.variable.type) .. " " .. localName(statement.variable.name) .. ";")
 		return
-	elseif statement.tag == "int" then
-		comment(statement.destination.name .. " = " .. statement.number .. ";")
-		local name = localName(statement.destination.name)
-		emit(name .. " = ALLOCATE(smol_Int);")
-		emit(name .. "->value = " .. luaEncodedNumber(statement.number) .. ";")
-		return
-	elseif statement.tag == "boolean" then
-		comment(statement.destination.name .. " = " .. tostring(statement.boolean) .. ";")
-		local name = localName(statement.destination.name)
-		emit(name .. " = ALLOCATE(smol_Boolean);")
-		emit(name .. "->value = " .. (statement.boolean and 1 or 0) .. ";")
-		return
-	elseif statement.tag == "this" then
-		comment(statement.destination.name .. " = this;")
-		emit(localName(statement.destination.name) .. " = this;")
-		return
-	elseif statement.tag == "unit" then
-		comment(statement.destination.name .. " = unit;")
-		emit(localName(statement.destination.name) .. " = NULL;")
+	elseif statement.tag == "nothing" then
+		program:comment("nothing statement")
 		return
 	elseif statement.tag == "assign" then
-		comment(statement.destination.name .. " = " .. statement.source.name .. ";")
-		emit(localName(statement.destination.name) .. " = " .. localName(statement.source.name) .. ";")
+		program:assign(localName(statement.destination.name), localName(statement.source.name))
+		return
+	elseif statement.tag == "return" then
+		local types = {}
+		local values = {}
+		for _, r in ipairs(statement.sources) do
+			table.insert(types, cType(r.type))
+			table.insert(values, localName(r.name))
+		end
+		local rhs = "(" .. program:getTuple(types) .. "){" .. table.concat(values, ", ") .. "}"
+		program:write("return " .. rhs .. ";")
+		return
+	elseif statement.tag == "if" then
+		local condition = localName(statement.condition.name) .. "->value"
+		program:write("if (" .. condition .. ") {")
+		generateStatement(statement.bodyThen, program:section(1), info)
+		program:write("} else {")
+		generateStatement(statement.bodyElse, program:section(1), info)
+		program:write("}")
+		return
+	elseif statement.tag == "int-load" then
+		local lhs = localName(statement.destination.name)
+		local rhs = "ALLOCATE(smol_Int_T)"
+		program:assign(lhs, rhs)
+		program:assign(lhs .. "->value", cEncodedNumber(statement.number))
 		return
 	elseif statement.tag == "new-class" then
-		comment(statement.destination.name .. " = new(...);")
-
-		-- Allocate a new instance
-		local name = localName(statement.destination.name)
-		local cT = cType(statement.destination.type, structScope)
-		assert(cT:sub(-1) == "*")
-		cT = cT:sub(1, -2)
-		emit(name .. " = ALLOCATE(" .. cT .. ");")
-
-		for key, value in spairs(statement.fields) do
-			emit(name .. "->" .. classFieldName(key) .. " = " .. localName(value.name) .. ";")
-		end
-		for key, constraint in spairs(statement.constraints) do
-			local constraintField = structConstraintField(key)
-			emit(name .. "->" .. constraintField .. " = " .. cConstraint(constraint, semantics) .. ";")
+		local lhs = localName(statement.destination.name)
+		local rhs = "ALLOCATE(" .. cType(statement.destination.type, true) .. ")"
+		program:assign(lhs, rhs)
+		for key, source in pairs(statement.fields) do
+			program:assign(lhs .. "->" .. classFieldName(key), localName(source.name))
 		end
 		return
 	elseif statement.tag == "new-union" then
-		comment(statement.destination.name .. " = new(" .. statement.field .. " = ...);")
+		local lhs = localName(statement.destination.name)
+		local rhs = "ALLOCATE(" .. cType(statement.destination.type, true) .. ")"
+		program:assign(lhs, rhs)
 
-		-- Allocate a new instance
-		local destination = localName(statement.destination.name)
-		local cT = cType(statement.destination.type, structScope)
-		assert(cT:sub(-1) == "*")
-		cT = cT:sub(1, -2)
-		emit(destination .. " = ALLOCATE(" .. cT .. ");")
-
-		local union = table.findwith(semantics.compounds, "name", statement.type.name)
-		assert(union and union.tag == "union")
-
-		-- Initialize the tag
-		emit(destination .. "->" .. TAG_FIELD .. " = " .. unionTagValue(union, statement.field) .. ";")
-
-		-- Initialize the value
-		local value = localName(statement.value.name)
-		emit(destination .. "->" .. unionFieldName(statement.field) .. " = " .. value .. ";")
-		return
-	elseif statement.tag == "return" then
-		comment("return ...;")
-
-		local types = {}
-		for _, source in ipairs(statement.sources) do
-			table.insert(types, cType(source.type, structScope))
-		end
-		local tuple = preTupleName(types)
-		local values = table.map(function(v) return localName(v.name) end, statement.sources)
-		emit("return " .. tuple .. "_make(" .. table.concat(values, ", ") .. ");")
-		return
-	elseif statement.tag == "if" then
-		comment("if ... {")
-		emit("if (" .. localName(statement.condition.name) .. "->value) {")
-		generateStatement(statement.bodyThen, indentedEmitter(emit), structScope, semantics, demandTuple)
-		emit("} else {")
-		generateStatement(statement.bodyElse, indentedEmitter(emit), structScope, semantics, demandTuple)
-		emit("}")
+		local defName = statement.destination.type.packageName .. ":" .. statement.destination.type.definitionName
+		local definition = info.unions[defName]
+		assert(definition)
+		local fieldID = cEncodedNumber(definition.tags[statement.field])
+		program:assign(lhs .. "->" .. TAG_FIELD, fieldID)
+		program:assign(lhs .. "->" .. unionFieldName(statement.field), localName(statement.value.name))
 		return
 	elseif statement.tag == "static-call" then
-		comment("... = " .. statement.signature.longName .. "(...);")
-		-- Collect value arguments
-		local argumentNames = {}
-		for _, argument in ipairs(statement.arguments) do
-			table.insert(argumentNames, localName(argument.name))
+		-- Generate constraints argument
+		local vtables = {}
+		local vtableTypes = {}
+		for _, a in ipairs(statement.constraintArguments) do
+			local vName, vType = generateVTable(a, program, info)
+			table.insert(vtables, vName)
+			table.insert(vtableTypes, vType)
+		end
+		
+		local cArguments = {}
+		if #vtables == 0 then
+			table.insert(cArguments, "NULL")
+		else
+			-- Create constraint argument
+			local cTmp = uniqueTmp()
+			local tupleType = program:getTuple(vtableTypes)
+			local tupleValue = "(" .. tupleType .. "){" .. table.concat(vtables, ", ") .. "}"
+			program:assign(tupleType .. " " .. cTmp, tupleValue)
+			table.insert(cArguments, "&" .. cTmp)
+		end
+		
+		-- Add regular value arguments
+		for _, a in ipairs(statement.arguments) do
+			table.insert(cArguments, localName(a.name))
 		end
 
-		-- Collect constraints
-		-- XXX: right now, we're guaranteed these are in lexical order
-		local keys = table.keys(statement.constraints)
-		table.sort(keys)
-		for _, key in ipairs(keys) do
-			local constraint = statement.constraints[key]
-			table.insert(argumentNames, cConstraint(constraint, semantics))
-		end
+		-- Invoke the function
+		local cName = staticFunctionName(statement.signature.longName)
+		local tmpType = program:getTuple(table.map(cType, statement.signature.returnTypes))
+		local tmp = uniqueTmp()
+		local invocation = cName .. "(" .. table.concat(cArguments, ", ") .. ")"
+		program:assign(tmpType .. " " .. tmp, invocation)
 
-		-- Emit code
-		local invocation = staticFunctionName(statement.signature.longName)
-		local arguments = table.concat(argumentNames, ", ")
-
-		local definition = table.findwith(semantics.compounds, "name", statement.baseType.name)
-		assert(definition)
-		local signature = statement.signature
-
-		local types = {}
-		for _, r in ipairs(signature.returnTypes) do
-			table.insert(types, cType(r, structScope))
-		end
-		local tuple = preTupleName(types)
-		local tmp = "_tmp" .. UID()
-		emit(tuple .. " " .. tmp .. " = " .. invocation .. "(" .. arguments .. ");")
-
-		-- Assign each resulting tuple
-		for i, destination in ipairs(statement.destinations) do
-			local cast = "(" .. cType(destination.type, structScope) .. ")"
-			emit(localName(destination.name) .. " = " .. cast .. tmp .. "._" .. i .. ";")
+		-- Write to destinations
+		for i, d in ipairs(statement.destinations) do
+			program:assign(localName(d.name), tmp .. "._" .. i)
 		end
 		return
-	elseif statement.tag == "method-call" then
-		comment("... = " .. statement.signature.longName .. "(...);")
+	elseif statement.tag == "dynamic-call" then
+		local vName, vType = generateVTable(statement.constraint, program, info)
 
-		-- Collect C arguments
-		local argumentNames = {}
-
-		-- Add the self argument
-		table.insert(argumentNames, localName(statement.baseInstance.name))
-
-		-- Add explicit value arguments
-		for _, argument in ipairs(statement.arguments) do
-			table.insert(argumentNames, localName(argument.name))
-		end
-		local arguments = table.concat(argumentNames, ", ")
-
-		-- Get the signature
-		local baseName = statement.baseInstance.type.name
-		local compound = table.findwith(semantics.compounds, "name", baseName)
-		local builtin = table.findwith(semantics.builtins, "name", baseName)
-		local definition = compound or builtin
-		assert(definition)
-		local signature = statement.signature
-
-		-- Get the C return-type of the function (which may not be the same
-		-- as the definitions because of generics)
-		local destinationTypes = {}
-		for _, returnType in ipairs(signature.returnTypes) do
-			table.insert(destinationTypes, cType(returnType, structScope))
+		-- Add regular value arguments
+		local cArguments = {}
+		for _, a in ipairs(statement.arguments) do
+			table.insert(cArguments, localName(a.name))
 		end
 
-		local tmp = "tmp" .. UID()
+		-- Invoke the function
+		local tmpType = program:getTuple(table.map(cType, statement.signature.returnTypes))
+		local tmp = uniqueTmp()
+		local closure = vName .. "." .. vtableMemberName(statement.signature.memberName)
+		local invocation = "CLOSURE_CALL(" .. closure .. ", " .. table.concat(cArguments, ", ") .. ")"
+		program:assign(tmpType .. " " .. tmp, invocation)
 
-		local tuple = preTupleName(destinationTypes)
-		local invocation = methodFunctionName(signature.longName) .. "(" .. arguments .. ")"
-		emit(tuple .. " " .. tmp .. " = " .. invocation .. ";")
-		for i, destination in ipairs(statement.destinations) do
-			emit(localName(destination.name) .. " = " .. tmp .. "._" .. i .. ";")
+		-- Write to destinations
+		for i, d in ipairs(statement.destinations) do
+			program:assign(localName(d.name), tmp .. "._" .. i)
 		end
+		return
+	elseif statement.tag == "boolean" then
+		local lhs = localName(statement.destination.name)
+		local rhs = "ALLOCATE(smol_Boolean_T)"
+		program:assign(lhs, rhs)
+		program:assign(lhs .. "->value", statement.boolean and 1 or 0)
 		return
 	elseif statement.tag == "field" then
-		comment(statement.destination.name .. " = " .. statement.base.name .. "." .. statement.name .. ";")
-		emit(localName(statement.destination.name) .. " = ")
-		emit("\t" .. localName(statement.base.name) .. "->" .. classFieldName(statement.name) .. ";")
+		local lhs = localName(statement.destination.name)
+		local rhs = localName(statement.base.name) .. "->" .. classFieldName(statement.name)
+		program:assign(lhs, rhs)
 		return
-	elseif statement.tag == "generic-static-call" then
-		comment("... = " .. "... ." .. statement.signature.longName .. "(...);")
-
-		-- Collect explicit arguments
-		local argumentValues = {}
-		for _, argument in ipairs(statement.arguments) do
-			table.insert(argumentValues, localName(argument.name))
-		end
-
-		if #argumentValues < 1 then
-			-- Closure calls must be given at least one argument
-			table.insert(argumentValues, "NULL")
-		end
-		local arguments = table.concat(argumentValues, ", ")
-
-		local interface = table.findwith(semantics.interfaces, "name", statement.constraint.interface.name)
-		assert(interface)
-		local signature = statement.signature
-
-		local destinationTypes = {}
-		for _, returnType in ipairs(signature.returnTypes) do
-			table.insert(destinationTypes, cType(returnType, structScope))
-		end
-		local tuple = preTupleName(destinationTypes)
-
-		local constraint = cConstraint(statement.constraint, semantics)
-		local member = interfaceMember(statement.signature.memberName)
-		local invocation = "CLOSURE_CALL(" .. constraint .. "->" .. member .. ", " .. arguments .. ")"
-		local tmp = "tmp" .. UID()
-		emit(tuple .. " " .. tmp .. " = " .. invocation .. ";")
-
-		-- Assign from tmp
-		for i, destination in ipairs(statement.destinations) do
-			emit(localName(destination.name) .. " = " .. tmp .. "._" .. i .. ";")
-		end
-		return
-	elseif statement.tag == "generic-method-call" then
-		comment("... = " .. statement.signature.longName .. "(...);")
-		local destinations = table.map(function(x) return localName(x.name) end, statement.destinations)
-
-		-- Collect the arguments
-		local argumentValues = {}
-
-		-- The first argument is the implicit this
-		table.insert(argumentValues, localName(statement.baseInstance.name))
-
-		-- Add explicit arguments
-		for _, argument in ipairs(statement.arguments) do
-			table.insert(argumentValues, localName(argument.name))
-		end
-
-		local arguments = table.concat(argumentValues, ", ")
-
-		local interface = table.findwith(semantics.interfaces, "name", statement.constraint.interface.name)
-		assert(interface)
-		local signature = statement.signature
-
-		local tmp = "_tmp" .. UID()
-		local outType = cTypeTuple(signature.returnTypes, demandTuple, structScope)
-		emit(outType .. " " .. tmp .. " = CLOSURE_CALL(" .. cConstraint(statement.constraint, semantics) .. "->" .. interfaceMember(signature.memberName) .. ", " .. arguments .. ");")
-		for i, destination in ipairs(statement.destinations) do
-			emit(localName(destination.name) .. " = " .. tmp .. "._" .. i .. ";")
-		end
-		return
-	elseif statement.tag == "match" then
-		comment("match " .. statement.base.name .. " {")
-		assert(#statement.cases >= 1)
-		for i, case in ipairs(statement.cases) do
-			if i > 1 then
-				emit("else")
-			end
-			local id = tostring(i)
-			comment("case ? " .. case.variant)
-			emit("if (" .. localName(statement.base.name) .. "->" .. TAG_FIELD .. " == " .. id .. ") {")
-			generateStatement(case.statement, indentedEmitter(emit), structScope, semantics, demandTuple)
-			emit("}")
-		end
-		emit("else { assert(0); }")
-		comment("}")
+	elseif statement.tag == "unit" then
+		local lhs = localName(statement.destination.name)
+		program:assign(lhs, "NULL")
 		return
 	elseif statement.tag == "variant" then
-		comment(statement.destination.name .. " = " .. statement.base.name .. "." .. statement.variant .. "; (union)")
-		emit(localName(statement.destination.name) .. " = ")
-		emit("\t" .. localName(statement.base.name) .. "->" .. unionFieldName(statement.variant) .. ";")
+		local lhs = localName(statement.destination.name)
+		local rhs = localName(statement.base.name) .. "->" .. unionFieldName(statement.variant)
+		program:assign(lhs, rhs)
 		return
-	elseif statement.tag == "assume" then
-		error "assume statements should be guarded by proof"
-	elseif statement.tag == "verify" then
-		error "verify statements should be guarded by proof"
-	elseif statement.tag == "proof" then
-		comment("proof")
-		return
+	elseif statement.tag == "match" then
+		error "TODO! match"
 	elseif statement.tag == "isa" then
-		comment(statement.destination.name .. " = " .. statement.base.name .. " isa " .. statement.variant)
-		emit(localName(statement.destination.name) .. " = ALLOCATE(smol_Boolean);")
-		local union = table.findwith(semantics.compounds, "name", statement.base.type.name)
-		assert(union and union.tag == "union")
-
-		-- Set value
-		local tagValue = unionTagValue(union, statement.variant)
-		local rhs = localName(statement.base.name) .. "->tag == " .. tagValue
-		emit(localName(statement.destination.name) .. "->value = " .. rhs .. ";")
-		return
+		error "TODO! isa"
 	end
 
-	comment(statement.tag .. " ????")
-	print("unknown statement tag `" .. statement.tag .. "`")
-end
-
--- RETURNS a C function identifier
-local function cEqMethodName(kind, name)
-	assert(kind == "class" or kind == "union")
-	assertis(name, "string")
-
-	return "smol_eq_" .. kind .. "_" .. name:gsub(":", "_")
+	error("unknown statement tag `" .. statement.tag .. "`")
 end
 
 return function(semantics, arguments)
@@ -597,8 +694,12 @@ return function(semantics, arguments)
 		quit("Could not open file `" .. arguments.out .. "` for writing")
 	end
 
-	local code = {"// Generated by Smol Lua compiler", commented(INVOKATION), ""}
-	table.insert(code, [[
+	local code = CProgram.new()
+	code.preamble:write("// Generated by Smol Lua compiler ")
+	code.preamble:write(commented(INVOKATION))
+	code.preamble:write("")
+
+	code.preamble:write([[
 #include "assert.h"
 #include "stdint.h"
 #include "stdio.h"
@@ -612,7 +713,7 @@ return function(semantics, arguments)
 #define PANIC(message) do { printf(message "\n"); exit(1); } while (0)
 
 // NOTE: closures must take at least one argument
-#define CLOSURE(returnType, ...)                \
+#define CLOSURE_TYPE(returnType, ...)           \
 	struct {                                    \
 		void* data;                             \
 		returnType (*func)(void*, __VA_ARGS__); \
@@ -624,704 +725,206 @@ typedef struct {
 	void* instance;
 	int (*eq)(void*, void*);
 	void (*destruct)(void*);
-} object_t;
+} object_T;
 
-]])
-
-	local forwardSequence = {}
-	table.insert(code, "// Forward type declarations")
-	table.insert(code, forwardSequence)
-	table.insert(code, "")
-	local function forwardDeclareStruct(private, public)
-		assertis(private, "string")
-		assert(not private:find(";"))
-		assertis(public, "string")
-
-		table.insert(forwardSequence, "struct " .. private .. "; typedef struct " .. private .. " " .. public .. ";")
-	end
-
-	table.insert(code, "// Tuples")
-	local tupleSequence = {}
-	table.insert(code, tupleSequence)
-	table.insert(code, "")
-
-	-- RETURNS a string that is a C type
-	local generatedTuples = {}
-	local function demandTuple(list)
-		assert(list, listType "string")
-
-		-- TODO: deal with 0-tuples
-		local name = preTupleName(list)
-		if not generatedTuples[name] then
-			generatedTuples[name] = true
-			local sequence = {}
-			-- Open struct impl
-			table.insert(sequence, "struct _" .. name .. " {")
-			local parameters = {}
-			for i = 1, #list do
-				table.insert(parameters, list[i] .. " _" .. i)
-				table.insert(sequence, "\t" .. list[i] .. " _" .. i .. ";")
-			end
-			if #list == 0 then
-				table.insert(sequence, "\tchar _;")
-			end
-
-			-- Close struct
-			table.insert(sequence, "};")
-			table.insert(sequence, "")
-
-			table.insert(sequence, name .. " " .. name .. "_make(" .. table.concat(parameters, ", ") .. ") {")
-			table.insert(sequence, "\t" .. name .. " out;")
-			for i = 1, #list do
-				table.insert(sequence, "\tout._" .. i .. " = _" .. i .. ";")
-			end
-			table.insert(sequence, "\treturn out;")
-			table.insert(sequence, "}")
-			table.insert(sequence, "")
-			table.insert(tupleSequence, table.concat(sequence, "\n"))
-			forwardDeclareStruct("_" .. name, name)
-		end
-		return name
-	end
-
-	table.insert(code, [[
-struct _smol_Unit {
-	void* nothing;
-};
-
-struct _smol_Boolean {
-	int value;
-};
-
-struct _smol_String {
-	size_t length;
-	char* text;
-};
-
-struct _smol_Int {
-	int64_t value;
-};
 
 ////////////////////////////////////////////////////////////////////////////////
 ]])
 
-	forwardDeclareStruct("_smol_Unit", "smol_Unit")
-	forwardDeclareStruct("_smol_Boolean", "smol_Boolean")
-	forwardDeclareStruct("_smol_Int", "smol_Int")
-	forwardDeclareStruct("_smol_String", "smol_String")
+	code:defineStruct("smol_Unit_T", {
+		{type = "void*", name = "nothing"},
+	})
 
-	-- Build the struct scope map
-	local structScope = {}
-	for _, compound in ipairs(semantics.compounds) do
-		assert(compound.tag == "class" or compound.tag == "union")
-		if compound.tag == "class" then
-			structScope[compound.name] = classStructName(compound.name)
-		elseif compound.tag == "union" then
-			structScope[compound.name] = unionStructName(compound.name)
-		end
-	end
-	structScope = freeze(structScope)
+	code:defineStruct("smol_Boolean_T", {
+		{type = "int", name = "value"},
+	})
 
-	-- Generate a struct for each interface
+	code:defineStruct("smol_String_T", {
+		{type = "size_t", name = "length"},
+		{type = "char*", name = "text"},
+	})
+
+	code:defineStruct("smol_Int_T", {
+		{type = "int64_t", name = "value"},
+	})
+	
+	-- Maintain some global information needed to compile statements
+	local globalInfo = {
+		constraints = {},
+		unions = {},
+	}
+
+	-- Generate a vtable struct for each interface
 	for _, interface in ipairs(semantics.interfaces) do
-		table.insert(code, "// interface " .. interface.name)
-		local structName = interfaceStructName(interface.name)
-		table.insert(code, "struct _" .. structName .. " {")
-		for _, signature in ipairs(interface.signatures) do
-			local returns = cTypeTuple(signature.returnTypes, demandTuple, structScope)
-			local name = interfaceMember(signature.memberName)
-			local parameters = {}
-			if signature.modifier == "method" then
-				table.insert(parameters, "void* /*this*/")
+		table.insert(code, "// interface " .. interface.fullName)
+		local structName = interfaceStructName(interface.fullName)
+		local fields = {{type = "char", name = "_"}}
+		local memberList = {}
+		for _, func in pairs(interface.functionMap) do
+			local signature = func.signature
+
+			-- Get return types
+			local rt = {}
+			for _, r in ipairs(signature.returnTypes) do
+				table.insert(rt, cType(r))
 			end
-			for _, parameter in ipairs(signature.parameters) do
-				table.insert(parameters, cType(parameter.type, structScope))
+			assert(1 <= #rt)
+
+			-- Get parameter types, padding with "void*" to get at least one
+			local pt = {}
+			for _, p in ipairs(signature.parameters) do
+				table.insert(pt, cType(p.type))
+			end
+			if #pt == 0 then
+				pt = {"void*"}
 			end
 
-			local prototype = #parameters == 0 and "void* /*ignore*/ " or table.concat(parameters, ", ")
-			table.insert(code, "\tCLOSURE(" .. returns .. ", " .. prototype .. ") " .. name .. ";")
+			table.insert(memberList, signature.memberName)
+			table.insert(fields, {
+				name = vtableMemberName(signature.memberName),
+				type = "CLOSURE_TYPE(" .. code:getTuple(rt) .. ", " .. table.concat(pt, ", ") .. ")",
+			})
 		end
-		table.insert(code, "\tchar _;")
-		table.insert(code, "};")
-		forwardDeclareStruct("_" .. structName, structName)
-		table.insert(code, "")
+
+		table.sort(memberList)
+		table.sort(fields, function(a, b)
+			return a.name < b.name
+		end)
+
+		-- Save struct info
+		globalInfo.constraints[interface.fullName] = {members = memberList}
+
+		code:defineStruct(structName, fields)
 	end
 
 	-- Generate a struct for each class
 	for _, class in ipairs(semantics.compounds) do
-		if class.tag == "class" then
-			table.insert(code, "// class " .. class.name)
-			local structName = classStructName(class.name)
-			table.insert(code, "struct _" .. structName .. " {")
-
-			-- Add a foreign field
-			table.insert(code, "\tvoid* foreign;")
+		if class.tag == "class-definition" then
+			local structName = compoundStructName(class.fullName)
+			local fields = {{type = "void*", name = "foreign"}}
 
 			-- Generate all value fields
-			for _, field in ipairs(class.fields) do
-				table.insert(code, "\t" .. cType(field.type, structScope) .. " " .. classFieldName(field.name) .. ";")
+			for _, field in pairs(class.fieldMap) do
+				table.insert(fields, {
+					name = classFieldName(field.name),
+					type = cType(field.type),
+				})
 			end
 
-			-- Generate all constraint fields
-			for i, generic in ipairs(class.generics) do
-				for j, constraint in ipairs(generic.constraints) do
-					local t = interfaceStructName(constraint.interface.name) .. "*"
-					-- XXX: constraint key
-					local key = "#" .. i .. "_" .. j
-					table.insert(code, "\t" .. t .. " " .. structConstraintField(key) .. ";")
-				end
-			end
-
-			table.insert(code, "};")
-			forwardDeclareStruct("_" .. structName, structName)
-			table.insert(code, "")
+			code:defineStruct(structName, fields)
 		end
 	end
 
 	-- Generate a tagged union for each union
 	for _, union in ipairs(semantics.compounds) do
-		if union.tag == "union" then
-			-- Open struct definition
-			table.insert(code, "// union " .. union.name)
-			local structName = unionStructName(union.name)
+		if union.tag == "union-definition" then
+			local structName = compoundStructName(union.fullName)
+			globalInfo.unions[union.fullName] = {tags = {}}
 
 			-- TODO: Generate a union rather than a struct
-			table.insert(code, "struct _" .. structName .. "{")
+			local fields = {{type = "uint32_t", name = TAG_FIELD}}
 
 			-- Generate tag
-			assert(#union.fields < 64)
-			table.insert(code, "\tunsigned " .. TAG_FIELD .. ";")
+			assert(#table.keys(union.fieldMap) < 2^16, "TODO: Too many fields!")
 
 			-- Generate all value fields
-			for _, field in ipairs(union.fields) do
-				table.insert(code, "\t" .. cType(field.type, structScope) .. " " .. unionFieldName(field.name) .. ";")
+			local fieldList = {}
+			for _, field in pairs(union.fieldMap) do
+				table.insert(fieldList, field.name)
+				table.insert(fields, {
+					type = cType(field.type),
+					name = unionFieldName(field.name),
+				})
+			end
+			table.sort(fields, function(a, b)
+				return a.name < b.name
+			end)
+			table.sort(fieldList)
+
+			-- Save tag map
+			for i, f in ipairs(fieldList) do
+				globalInfo.unions[union.fullName].tags[f] = i
 			end
 
-			-- Generate all constraint fields
-			for i, generic in ipairs(union.generics) do
-				for j, constraint in ipairs(generic.constraints) do
-					local t = interfaceStructName(constraint.interface.name) .. "*"
-					-- XXX: constraint key
-					local key = "#" .. i .. "_" .. j
-					table.insert(code, "\t" .. t .. " " .. structConstraintField(key) .. ";")
-				end
-			end
-
-			-- Close struct definition
-			table.insert(code, "};")
-			forwardDeclareStruct("_" .. structName, structName)
-			table.insert(code, "")
-		end
-	end
-
-	local prototypeSequence = {}
-	table.insert(code, prototypeSequence)
-	table.insert(code, "")
-	-- Add a prototype string to up here
-	local function genPrototype(prototype)
-		assert(prototype:find(" ") and prototype:find(";"))
-		table.insert(prototypeSequence, prototype)
-	end
-
-	-- Generate a constraint-building-function for each constraint
-	for _, definition in ipairs(semantics.compounds) do
-		for i, implement in ipairs(definition.implements) do
-			local requirements = {}
-			for key, constraint in spairs(definition.constraints) do
-				table.insert(requirements, {name = key, constraint = constraint})
-			end
-			table.sort(requirements, function(a, b) return a.name < b.name end)
-			local parameters = {}
-			local parameterTypes = {}
-			for j, p in ipairs(requirements) do
-				local t = interfaceStructName(p.constraint.name) .. "*"
-				table.insert(parameters, t .. " p" .. i .. "_" .. j)
-				table.insert(parameterTypes, t)
-			end
-
-			local interface = table.findwith(semantics.interfaces, "name", implement.name)
-			assert(interface)
-
-			-- Generate the wrapper for each method part of the interface
-			local wrapped = {}
-			for _, signature in ipairs(interface.signatures) do
-				table.insert(code, "// wrapper for impl")
-
-				local implementingSignature = table.findwith(definition.signatures, "memberName", signature.memberName)
-
-				-- Collect the constraints
-				local constraints = {}
-				for i, generic in ipairs(definition.generics) do
-					for j, constraint in ipairs(generic.constraints) do
-						table.insert(constraints, interfaceStructName(constraint.interface.name) .. "*")
-					end
-				end
-
-				local dataTupleType = demandTuple(constraints) .. "*"
-
-				-- Get the out type from the interface
-				local wrapperName = cWrapperName(signature.memberName, definition.name, interface.name)
-				wrapped[signature.memberName] = wrapperName
-				local outType = cTypeTuple(signature.returnTypes, demandTuple, structScope)
-				local cParameters = {"void* data_general"}
-
-				-- Add implicit this parameter
-				if signature.modifier == "method" then
-					table.insert(cParameters, "void* " .. C_THIS_LOCAL)
-				end
-
-				-- Add explicit value parameters
-				for _, parameter in ipairs(signature.parameters) do
-					local t = cType(parameter.type, structScope)
-					local name = localName(parameter.name)
-					table.insert(cParameters, t .. " " .. name)
-				end
-				if #cParameters == 1 then
-					table.insert(cParameters, "void* /*ignore*/ _")
-				end
-
-				-- Create prototype for wrapper
-				local prototype = outType .. " " .. wrapperName .. "(" .. table.concat(cParameters, ", ") .. ")"
-				table.insert(code, prototype .. " {")
-				table.insert(code, "\t" .. dataTupleType .. " data = data_general;")
-
-				-- Collect the value arguments for the implementation
-				local arguments = {}
-				if signature.modifier == "method" then
-					-- TODO: explicitly cast to correct type
-					local cast = "(void*)"
-					table.insert(arguments, cast .. C_THIS_LOCAL)
-				end
-
-				for _, parameter in ipairs(signature.parameters) do
-					table.insert(arguments, localName(parameter.name))
-				end
-
-				-- Collect the constraint arguments for the implementation
-				if signature.modifier == "static" then
-					-- Only static functions take parameters
-					for i, constraint in ipairs(constraints) do
-						table.insert(arguments, "data->_" .. i)
-					end
-				end
-
-				local implName
-				if signature.modifier == "static" then
-					implName = staticFunctionName(implementingSignature.longName)
-				else
-					implName = methodFunctionName(implementingSignature.longName)
-				end
-
-				local invocation = implName .. "(" .. table.concat(arguments, ", ") .. ")"
-
-				-- May need to convert tuple types
-				local func = table.findwith(definition.signatures, "memberName", signature.memberName)
-				local defOut = cTypeTuple(func.returnTypes, demandTuple, structScope)
-				local intOut = cTypeTuple(signature.returnTypes, demandTuple, structScope)
-				table.insert(code, "\t" .. defOut .. " concrete_out = " .. invocation .. ";")
-				table.insert(code, "\t" .. intOut .. " out;")
-				for i = 1, #signature.returnTypes do
-					table.insert(code, "\tout._" .. i .. " = concrete_out._" .. i .. ";")
-				end
-				table.insert(code, "\treturn out;")
-				table.insert(code, "}")
-			end
-
-			-- Generate the main function
-			local functionName = concreteConstraintFunctionName(definition.name, implement.name)
-			local outValueType = interfaceStructName(implement.name)
-			table.insert(code, "// " .. definition.name .. " implements " .. implement.name)
-			table.insert(code, outValueType .. "* " .. functionName .. "(" .. table.concat(parameters, ", ") .. ") {")
-			local tuple = demandTuple(parameterTypes)
-			table.insert(code, "\t" .. tuple .. "* closed = ALLOCATE(" .. tuple .. ");")
-			for j = 1, #parameters do
-				table.insert(code, "\tclosed->_" .. i .. " = p" .. i .. "_" .. j .. ";")
-			end
-
-			table.insert(code, "\t" .. outValueType .. "* out = ALLOCATE(" .. outValueType .. ");")
-			for _, signature in ipairs(interface.signatures) do
-				table.insert(code, "\tout->" .. interfaceMember(signature.memberName) .. ".data = closed;")
-				local func = wrapped[signature.memberName]
-				table.insert(code, "\tout->" .. interfaceMember(signature.memberName) .. ".func = " .. func .. ";")
-			end
-
-			table.insert(code, "\treturn out;")
-			table.insert(code, "}")
-			table.insert(code, "")
-		end
-	end
-
-	-- Add separator before functions
-	table.insert(code, string.rep("/", 80))
-	table.insert(code, "")
-
-	-- Generate the tuple types/prototypes for builtins
-	local builtinFuncs = {}
-	for _, builtin in ipairs(semantics.builtins) do
-		for _, signature in ipairs(builtin.signatures) do
-			-- Generate function header
-			local cFunctionName
-			local cParameters
-			if signature.modifier == "static" then
-				cFunctionName = staticFunctionName(signature.longName)
-				cParameters = {}
-			else
-				assert(signature.modifier == "method")
-				cFunctionName = methodFunctionName(signature.longName)
-				cParameters = {"smol_" .. builtin.name .. "* " .. C_THIS_LOCAL}
-			end
-
-			-- Add value parameters
-			for _, parameter in ipairs(signature.parameters) do
-				table.insert(cParameters, cType(parameter.type, structScope) .. " " .. localName(parameter.name))
-			end
-
-			local outType = cTypeTuple(signature.returnTypes, demandTuple, structScope)
-			local prototype = outType .. " " .. cFunctionName .. "(" .. table.concat(cParameters, ", ") .. ")"
-			genPrototype(prototype .. ";")
+			-- Create VTable struct
+			code:defineStruct(structName, fields)
 		end
 	end
 
 	-- Generate the body for each method and static
 	for _, func in ipairs(semantics.functions) do
-		local fullName = func.definitionName .. "." .. func.name
-		table.insert(code, "// " .. func.signature.modifier .. " " .. fullName)
-
-		local definition = table.findwith(semantics.compounds, "name", func.definitionName)
-		assert(definition)
-		local thisType = cDefinitionType(definition)
-
 		-- Generate function header
-		local cFunctionName
-		local cParameters
-		if func.signature.modifier == "static" then
-			cFunctionName = staticFunctionName(func.signature.longName)
-			cParameters = {}
-		else
-			assert(func.signature.modifier == "method")
-			cFunctionName = methodFunctionName(func.signature.longName)
-			cParameters = {thisType .. " " .. C_THIS_LOCAL}
+		local cFunctionName = staticFunctionName(func.signature.longName)
+		local cParameters = {}
+
+		-- Add constraint parameter(s)
+		local vtableTypes = {}
+		for _, constraintArgument in ipairs(func.constraintArguments) do
+			local t = cVTableType(constraintArgument.constraint)
+			table.insert(vtableTypes, t)
 		end
+		if #vtableTypes == 0 then
+			-- Pad tuple to length 1
+			table.insert(vtableTypes, "int")
+		end
+
+		table.insert(cParameters, {
+			type = code:getTuple(vtableTypes) .. "*",
+			name = CONSTRAINT_PARAMETER,
+		})
 
 		-- Add value parameters
-		for _, parameter in ipairs(func.parameters) do
-			table.insert(cParameters, cType(parameter.type, structScope) .. " " .. localName(parameter.name))
+		for _, parameter in ipairs(func.signature.parameters) do
+			table.insert(cParameters, {
+				type = cType(parameter.type),
+				name = localName(parameter.name),
+			})
 		end
 
-		-- Add constraint parameters
-		for i, generic in ipairs(func.generics) do
-			for j, constraint in ipairs(generic.constraints) do
-				local interface = constraint.interface
-				assertis(interface, "InterfaceType+")
+		-- Get the returns
+		local cOutType = code:getTuple(table.map(cType, func.signature.returnTypes))
 
-				local t = interfaceStructName(interface.name) .. "*"
-				local identifier = C_CONSTRAINT_PARAMETER_PREFIX .. "_" .. i .. "_" .. j
-				table.insert(cParameters, t .. " " .. identifier)
-			end
-		end
-		local outType = cTypeTuple(func.returnTypes, demandTuple, structScope)
-		local prototype = outType .. " " .. cFunctionName .. "(" .. table.concat(cParameters, ", ") .. ")"
-		genPrototype(prototype .. ";")
+		-- Generate the function prototype
+		local body = code:defineFunction(cFunctionName, cOutType, cParameters)
 
 		-- Generate function body
 		if not func.signature.foreign then
-			table.insert(code, prototype .. " {")
-			local function emit(line)
-				table.insert(code, "\t" .. line)
+			-- Get global information about the function
+			local parameterIndices = {}
+			for i, a in ipairs(func.constraintArguments) do
+				parameterIndices[a.name] = i
 			end
-			generateStatement(func.body, emit, structScope, semantics, demandTuple)
+			local info = table.with(globalInfo, "parameterIndices", parameterIndices)
 
-			-- Close function body
-			if func.body.returns ~= "yes" then
-				assert(#func.returnTypes == 1)
-				assert(func.returnTypes[1].tag == "keyword-type+")
-				assert(func.returnTypes[1].name == "Unit")
-
-				table.insert(code, "\treturn (tuple1_1_smol_Unit_ptr){NULL};")
-			end
-			table.insert(code, "}")
+			-- Compile the function
+			assert(func.body.returns == "yes")
+			generateStatement(func.body, body, info)
 		else
-			table.insert(code, "// is foreign")
+			-- Get body from table
+			local impl = FOREIGN_IMPLEMENTATION[func.signature.longName]
+			assert(impl, "no impl for foreign `" .. func.signature.longName .. "`")
+			body:comment("Foreign function `" .. func.signature.longName .. "`")
+			body:write(impl)
+
+			-- Wrap for tuple type
+			local rhs = "(" .. cOutType .. "){"
+			for i = 1, #func.signature.returnTypes do
+				if i ~= 1 then
+					rhs = rhs .. ", "
+				end
+				rhs = rhs .. "out" .. i
+			end
+			rhs = rhs .. "}"
+			body:write("return " .. rhs .. ";")
 		end
-		table.insert(code, "")
 	end
-
-	table.insert(code, [[
-////////////////////////////////////////////////////////////////////////////////
-
-// Boolean method and(Boolean) Boolean
-tuple1_1_smol_Boolean_ptr smol_method_Boolean_and(smol_Boolean* this, smol_Boolean* other) {
-	tuple1_1_smol_Boolean_ptr out;
-	out._1 = ALLOCATE(smol_Boolean);
-	out._1->value = this->value && other->value;
-	return out;
-}
-
-// Boolean method or(Boolean) Boolean
-tuple1_1_smol_Boolean_ptr smol_method_Boolean_or(smol_Boolean* this, smol_Boolean* other) {
-	tuple1_1_smol_Boolean_ptr out;
-	out._1 = ALLOCATE(smol_Boolean);
-	out._1->value = this->value || other->value;
-	return out;
-}
-
-// Boolean method not() Boolean
-tuple1_1_smol_Boolean_ptr smol_method_Boolean_not(smol_Boolean* this) {
-	tuple1_1_smol_Boolean_ptr out;
-	out._1 = ALLOCATE(smol_Boolean);
-	out._1->value = !this->value;
-	return out;
-}
-
-// Boolean method implies(Boolean) Boolean
-tuple1_1_smol_Boolean_ptr smol_method_Boolean_implies(smol_Boolean* this, smol_Boolean* other) {
-	tuple1_1_smol_Boolean_ptr out;
-	out._1 = ALLOCATE(smol_Boolean);
-	out._1->value = !this->value || other->value;
-	return out;
-}
-
-// Boolean method eq(Boolean) Boolean
-tuple1_1_smol_Boolean_ptr smol_method_Boolean_eq(smol_Boolean* this, smol_Boolean* other) {
-	tuple1_1_smol_Boolean_ptr out;
-	out._1 = ALLOCATE(smol_Boolean);
-	out._1->value = this->value == other->value;
-	return out;
-}
-
-// Int method isPositive() Boolean
-tuple1_1_smol_Boolean_ptr smol_method_Int_isPositive(smol_Int* this) {
-	tuple1_1_smol_Boolean_ptr out;
-	out._1 = ALLOCATE(smol_Boolean);
-	out._1->value = this->value > 0;
-	return out;
-}
-
-// Int method negate() Int
-tuple1_1_smol_Int_ptr smol_method_Int_negate(smol_Int* this) {
-	tuple1_1_smol_Int_ptr out;
-	out._1 = ALLOCATE(smol_Int);
-	out._1->value = -this->value;
-	return out;
-}
-
-// Int method lessThan(Int) Boolean
-tuple1_1_smol_Boolean_ptr smol_method_Int_lessThan(smol_Int* this, smol_Int* smol_local_one) {
-	tuple1_1_smol_Boolean_ptr out;
-	out._1 = ALLOCATE(smol_Boolean);
-	out._1->value = this->value < smol_local_one->value;
-	return out;
-}
-
-// Int method eq(Int) Boolean
-tuple1_1_smol_Boolean_ptr smol_method_Int_eq(smol_Int* this, smol_Int* smol_local_other) {
-	tuple1_1_smol_Boolean_ptr out;
-	out._1 = ALLOCATE(smol_Boolean);
-	out._1->value = this->value == smol_local_other->value;
-	return out;
-}
-
-// Int method quotient(Int) Int
-tuple1_1_smol_Int_ptr smol_method_Int_quotient(smol_Int* this, smol_Int* smol_local_other) {
-	tuple1_1_smol_Int_ptr out;
-	out._1 = ALLOCATE(smol_Int);
-	out._1->value = this->value / smol_local_other->value;
-	return out;
-}
-
-// Int method product(Int) Int
-tuple1_1_smol_Int_ptr smol_method_Int_product(smol_Int* this, smol_Int* smol_local_other) {
-	tuple1_1_smol_Int_ptr out;
-	out._1 = ALLOCATE(smol_Int);
-	out._1->value = this->value * smol_local_other->value;
-	return out;
-}
-
-// Int method sum(Int) Int
-tuple1_1_smol_Int_ptr smol_method_Int_sum(smol_Int* this, smol_Int* smol_local_other) {
-	tuple1_1_smol_Int_ptr out;
-	out._1 = ALLOCATE(smol_Int);
-	out._1->value = this->value + smol_local_other->value;
-	return out;
-}
-
-// Int method difference(Int) Int
-tuple1_1_smol_Int_ptr smol_method_Int_difference(smol_Int* this, smol_Int* smol_local_other) {
-	tuple1_1_smol_Int_ptr out;
-	out._1 = ALLOCATE(smol_Int);
-	out._1->value = this->value - smol_local_other->value;
-	return out;
-}
-
-// String method concatenate(String) String
-tuple1_1_smol_String_ptr smol_method_String_concatenate(smol_String* this, smol_String* other) {
-	tuple1_1_smol_String_ptr out;
-	out._1 = ALLOCATE(smol_String);
-	out._1->length = this->length + other->length;
-	out._1->text = ALLOCATE_ARRAY(out._1->length, char);
-	for (size_t i = 0; i < this->length; i++) {
-		out._1->text[i] = this->text[i];
-	}
-	for (size_t i = 0; i < other->length; i++) {
-		out._1->text[i + this->length] = other->text[i];
-	}
-	return out;
-}
-
-// String method eq(String) Boolean
-tuple1_1_smol_Boolean_ptr smol_method_String_eq(smol_String* this, smol_String* other) {
-	tuple1_1_smol_Boolean_ptr out;
-	out._1 = ALLOCATE(smol_Boolean);
-	size_t length = this->length;
-	if (length != other->length) {
-		out._1->value = 0;
-	} else {
-		out._1->value = 0 == memcmp(this->text, other->text, length);
-	}
-	return out;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-
-// core:Out static println(String) Unit
-tuple1_1_smol_Unit_ptr smol_static_core_Out_println(smol_String* message) {
-	// TODO: allow nulls, etc.
-	for (size_t i = 0; i < message->length; i++) {
-		putchar(message->text[i]);
-	}
-	printf("\n");
-	return (tuple1_1_smol_Unit_ptr){0};
-}
-
-// <Arrays>
-typedef struct {
-	size_t size;
-	void** data;
-} realarray;
-
-// core:Array[#T] static make() Array[#T]
-tuple1_1_smol_class_core_Array_T_ptr smol_static_core_Array_make() {
-	realarray* real = ALLOCATE(realarray);
-	real->size = 0;
-	real->data = NULL;
-
-	smol_class_core_Array_T* out = ALLOCATE(smol_class_core_Array_T);
-	out->foreign = real;
-	return (tuple1_1_smol_class_core_Array_T_ptr){out};
-}
-
-// core:Array[#T] method get(Int) #T
-tuple1_1_void_ptr smol_method_core_Array_get(smol_class_core_Array_T* this, smol_Int* smol_local_index) {
-	realarray* real = this->foreign;
-	if (smol_local_index->value < 0) {
-		PANIC("negative array index");
-	} else if (smol_local_index->value >= (int)real->size) {
-		PANIC("past end array index");
-	}
-	void* out = real->data[smol_local_index->value];
-	return (tuple1_1_void_ptr){out};
-}
-
-// core:Array[#T] method set(Int, #T) Array[#T]
-tuple1_1_smol_class_core_Array_T_ptr smol_method_core_Array_set(smol_class_core_Array_T* this, smol_Int* smol_local_index, void* smol_local_value) {
-	realarray* old = this->foreign;
-	if (smol_local_index->value < 0) {
-		PANIC("negative array index");
-	} else if (smol_local_index->value >= (int)old->size) {
-		PANIC("past end array index");
-	}
-
-	realarray* prime = ALLOCATE(realarray);
-	prime->size = old->size;
-	prime->data = ALLOCATE_ARRAY(prime->size, void*);
-	for (size_t i = 0; i < old->size; i++) {
-		prime->data[i] = old->data[i];
-	}
-
-	// Update the value
-	prime->data[smol_local_index->value] = smol_local_value;
-
-	smol_class_core_Array_T* out = ALLOCATE(smol_class_core_Array_T);
-	out->foreign = prime;
-
-	return (tuple1_1_smol_class_core_Array_T_ptr){out};
-}
-
-// core:Array method append(#T) Array[#T]
-tuple1_1_smol_class_core_Array_T_ptr smol_method_core_Array_append(smol_class_core_Array_T* this, void* smol_local_value) {
-	realarray* old = this->foreign;
-	realarray* prime = ALLOCATE(realarray);
-	prime->size = old->size + 1;
-	prime->data = ALLOCATE_ARRAY(prime->size, void*);
-	for (size_t i = 0; i < old->size; i++) {
-		prime->data[i] = old->data[i];
-	}
-
-	// Update the value
-	prime->data[old->size] = smol_local_value;
-
-	smol_class_core_Array_T* out = ALLOCATE(smol_class_core_Array_T);
-	out->foreign = prime;
-
-	return (tuple1_1_smol_class_core_Array_T_ptr){out};
-}
-
-// core:Array method pop() Array[#T]
-tuple1_1_smol_class_core_Array_T_ptr smol_method_core_Array_pop(smol_class_core_Array_T* this) {
-	realarray* old = this->foreign;
-	realarray* prime = ALLOCATE(realarray);
-	prime->size = old->size - 1;
-	prime->data = ALLOCATE_ARRAY(prime->size, void*);
-	for (size_t i = 0; i < old->size - 1; i++) {
-		prime->data[i] = old->data[i];
-	}
-
-	smol_class_core_Array_T* out = ALLOCATE(smol_class_core_Array_T);
-	out->foreign = prime;
-
-	return (tuple1_1_smol_class_core_Array_T_ptr){out};
-}
-
-// core:Array method size() Int
-tuple1_1_smol_Int_ptr smol_method_core_Array_size(smol_class_core_Array_T* this) {
-	realarray* real = this->foreign;
-	smol_Int* out = ALLOCATE(smol_Int);
-	out->value = (int64_t)real->size;
-	return (tuple1_1_smol_Int_ptr){out};
-}
-
-// core:ASCII static formatInt(Int) String
-tuple1_1_smol_String_ptr smol_static_core_ASCII_formatInt(smol_Int* smol_local_value) {
-	tuple1_1_smol_String_ptr out;
-	out._1 = ALLOCATE(smol_String);
-	out._1->text = ALLOCATE_ARRAY(32, char);
-	out._1->length = (size_t)sprintf(out._1->text, "%" PRId64, smol_local_value->value);
-	return out;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-]])
-
-	demandTuple {"smol_String*"}
-	demandTuple {"smol_class_core_Array_T*"}
 
 	-- Generate the main function
-	table.insert(code, "// Main " .. semantics.main)
-	table.insert(code, "int main(int argv, char** argc) {")
-	table.insert(code, "\t" .. staticFunctionName(semantics.main .. ":main") .. "();")
-	table.insert(code, "\treturn 0;")
-	table.insert(code, "}")
+	local main = code:defineFunction("main", "int", {{name = "argc", type = "int"}, {name = "argv", type = "char**"}})
+	main:write(staticFunctionName(semantics.main .. ":main") .. "(NULL);")
+	main:write("return 0;")
 
 	-- Write the code to the output file
-	for _, line in ipairs(code) do
-		if type(line) == "string" then
-			file:write(line .. "\n")
-		else
-			assertis(line, listType "string")
-			for _, subline in ipairs(line) do
-				file:write(subline .. "\n")
-			end
-		end
-	end
+	file:write(code:serialize())
 	file:close()
 end

--- a/src/codegen/genc.lua
+++ b/src/codegen/genc.lua
@@ -81,42 +81,42 @@ FOREIGN_IMPLEMENTATION["Boolean:or"] = [[
 
 FOREIGN_IMPLEMENTATION["Int:difference"] = [[
 	smol_Int_T* out1 = ALLOCATE(smol_Int_T);
-	out1->value = smol_local_arg1->value - smol_local_arg2->value;
+	out1->value = smol_local_this->value - smol_local_arg2->value;
 ]]
 
 FOREIGN_IMPLEMENTATION["Int:sum"] = [[
 	smol_Int_T* out1 = ALLOCATE(smol_Int_T);
-	out1->value = smol_local_arg1->value + smol_local_arg2->value;
+	out1->value = smol_local_this->value + smol_local_arg2->value;
 ]]
 
 FOREIGN_IMPLEMENTATION["Int:product"] = [[
 	smol_Int_T* out1 = ALLOCATE(smol_Int_T);
-	out1->value = smol_local_arg1->value * smol_local_arg2->value;
+	out1->value = smol_local_this->value * smol_local_arg2->value;
 ]]
 
 FOREIGN_IMPLEMENTATION["Int:quotient"] = [[
 	smol_Int_T* out1 = ALLOCATE(smol_Int_T);
-	out1->value = smol_local_arg1->value / smol_local_arg2->value;
+	out1->value = smol_local_this->value / smol_local_arg2->value;
 ]]
 
 FOREIGN_IMPLEMENTATION["Int:negate"] = [[
 	smol_Int_T* out1 = ALLOCATE(smol_Int_T);
-	out1->value = -smol_local_arg1->value;
+	out1->value = -smol_local_this->value;
 ]]
 
 FOREIGN_IMPLEMENTATION["Int:lessThan"] = [[
 	smol_Boolean_T* out1 = ALLOCATE(smol_Boolean_T);
-	out1->value = smol_local_arg1->value < smol_local_arg2->value;
+	out1->value = smol_local_this->value < smol_local_arg2->value;
 ]]
 
 FOREIGN_IMPLEMENTATION["Int:eq"] = [[
 	smol_Boolean_T* out1 = ALLOCATE(smol_Boolean_T);
-	out1->value = smol_local_arg1->value == smol_local_arg2->value;
+	out1->value = smol_local_this->value == smol_local_arg2->value;
 ]]
 
 FOREIGN_IMPLEMENTATION["Int:isPositive"] = [[
 	smol_Boolean_T* out1 = ALLOCATE(smol_Boolean_T);
-	out1->value = 0 < smol_local_arg1->value;
+	out1->value = 0 < smol_local_this->value;
 ]]
 
 --------------------------------------------------------------------------------

--- a/src/codegen/genc.lua
+++ b/src/codegen/genc.lua
@@ -635,7 +635,11 @@ local function generateStatement(statement, program, info)
 	program:comment(statement.tag)
 
 	if statement.tag == "proof" then
-		program:comment("skipping proof")
+		if statement.returns == "yes" then
+			program:write("assert(0); // assert false;")
+		else
+			program:comment("skipping proof")
+		end
 		return
 	elseif statement.tag == "sequence" then
 		for _, s in ipairs(statement.statements) do

--- a/src/codegen/genc.lua
+++ b/src/codegen/genc.lua
@@ -818,10 +818,6 @@ local function generateStatement(statement, program, info)
 			end
 			program:write("if (" .. tagVar .. " == " .. tagValue .. ") {")
 			local body = program:section(1)
-			local caseType = cType(case.variable.type)
-			local caseName = localName(case.variable.name)
-			local caseValue = localName(statement.base.name) .. "->" .. unionFieldName(case.variant)
-			body:assign(caseType .. " " .. caseName, caseValue)
 			generateStatement(case.statement, body, info)
 			program:write("}")
 		end

--- a/src/common.lua
+++ b/src/common.lua
@@ -45,6 +45,21 @@ local function showConstraintKind(c)
 	error "unknown ConstraintKind tag"
 end
 
+-- RETURNS a description of the given Signature as a string of Smol code
+local function showSignature(s)
+	assertis(s, "Signature")
+
+	local parameters = {}
+	for _, p in ipairs(s.parameters) do
+		table.insert(parameters, showTypeKind(p.type))
+	end
+	local parameterList = "(" .. table.concat(parameters, ", ") .. ") "
+
+	local returnTypes = table.map(showTypeKind, s.returnTypes)
+	local returnList = table.concat(returnTypes, ", ")
+	return s.modifier .. " " .. s.memberName .. parameterList .. returnList
+end
+
 -- RETURNS whether or not two given types are the same
 local function areTypesEqual(a, b)
 	assertis(a, "TypeKind")
@@ -462,6 +477,7 @@ return {
 	assertionExprString = assertionExprString,
 	showTypeKind = showTypeKind,
 	showConstraintKind = showConstraintKind,
+	showSignature = showSignature,
 
 	typeOfAssertion = typeOfAssertion,
 
@@ -474,6 +490,7 @@ return {
 	builtinDefinitions = {
 		-- Boolean
 		Boolean = {
+			isBuiltIn = true,
 			tag = "class-definition",
 			constraintArguments = {},
 			fieldMap = {},
@@ -614,6 +631,7 @@ return {
 
 		-- Int
 		Int = {
+			isBuiltIn = true,
 			tag = "class-definition",
 			constraintArguments = {},
 
@@ -715,6 +733,7 @@ return {
 
 		-- String
 		String = {
+			isBuiltIn = true,
 			tag = "class-definition",
 			constraintArguments = {},
 			fieldMap = {},

--- a/src/common.lua
+++ b/src/common.lua
@@ -646,13 +646,13 @@ local BUILTIN_DEFINITIONS = {
 					end,
 					ensuresASTs = {
 						-- Transitive
-						parseKind("ensures (forall (middle Int) return when (this < middle).and(middle < right))", "ensures"),
+						parseKind("ensures (forall (middle Int) return when (this < middle).and(middle < arg2))", "ensures"),
 
 						-- Antireflexive
-						parseKind("ensures return.not() when this == right", "ensures"),
+						parseKind("ensures return.not() when this == arg2", "ensures"),
 
 						-- Antisymmetric
-						parseKind("ensures return.not() when right < this", "ensures"),
+						parseKind("ensures return.not() when arg2 < this", "ensures"),
 					},
 				}),
 				bodyAST = false,
@@ -705,7 +705,7 @@ local BUILTIN_DEFINITIONS = {
 					end,
 					ensuresASTs = {
 						-- Ordered field
-						parseKind("ensures this < return when 0 < right", "ensures"),
+						parseKind("ensures this < return when 0 < arg2", "ensures"),
 					},
 				}),
 				bodyAST = false,

--- a/src/common.lua
+++ b/src/common.lua
@@ -361,6 +361,19 @@ local function showStatement(statement, indent)
 		table.insert(x, "\n" .. indent .. "else\n")
 		table.insert(x, showStatement(statement.bodyElse, indent .. "\t"))
 		return table.concat(x, "")
+	elseif statement.tag == "match" then
+		local x = {}
+		table.insert(x, pre)
+		table.insert(x, " ")
+		table.insert(x, statement.base.name)
+		table.insert(x, "\n")
+		for _, c in ipairs(statement.cases) do
+			table.insert(x, indent .. "case " .. c.variant)
+			table.insert(x, "\n")
+			table.insert(x, showStatement(c.statement, indent .. "\t"))
+			table.insert(x, "\n")
+		end
+		return table.concat(x, "")
 	elseif statement.tag == "this" then
 		return pre .. " " .. statement.destination.name
 	elseif statement.tag == "field" then

--- a/src/common.lua
+++ b/src/common.lua
@@ -397,6 +397,9 @@ local function showStatement(statement, indent)
 	elseif statement.tag == "boolean" then
 		local rhs = tostring(statement.boolean)
 		return pre .. " " .. statement.destination.name .. " := " .. rhs
+	elseif statement.tag == "int-load" then
+		local rhs = tostring(statement.number)
+		return pre .. " " .. statement.destination.name .. " := " .. rhs
 	else
 		return pre .. " <?>"
 	end

--- a/src/common.lua
+++ b/src/common.lua
@@ -745,6 +745,15 @@ local BUILTIN_DEFINITIONS = {
 	},
 }
 
+for _, d in pairs(BUILTIN_DEFINITIONS) do
+	d.resolverContext = {
+		selfAllowed = false,
+		generics = {},
+		checkConstraints = true,
+		template = false,
+	}
+end
+
 --------------------------------------------------------------------------------
 
 return {

--- a/src/compiler.lua
+++ b/src/compiler.lua
@@ -238,37 +238,8 @@ class Out {
 	foreign static println!(message String) Unit;
 }
 
-class Array[#T] {
-	foreign static make() Array[#T];
-	foreign method get(index Int) #T;
-	foreign method set(index Int, value #T) Array[#T];
-	foreign method append(value #T) Array[#T];
-	foreign method pop() Array[#T];
-	foreign method size() Int;
-
-	method swap(a Int, b Int) Array[#T] {
-		return this.set(a, this.get(b)).set(b, this.get(a));
-	}
-}
-
 class ASCII {
 	foreign static formatInt(value Int) String;
-}
-
-class ArrayShower[#T | #T is Showable] {
-	static inner(array Array[#T], index Int) String {
-		if array.size() == index {
-			return "";
-		} elseif index == 0 {
-			return array.get(0).show() ++ ArrayShower[#T].inner(array, 1);
-		}
-		return (", " ++ array.get(index).show()) ++ ArrayShower[#T].inner(array, index + 1);
-	}
-
-	static show(array Array[#T]) String {
-		var inner String = ArrayShower[#T].inner(array, 0);
-		return ("[" ++ inner) ++ "]";
-	}
 }
 
 interface Showable {

--- a/src/compiler.lua
+++ b/src/compiler.lua
@@ -34,6 +34,10 @@ local ansi = import "ansi.lua"
 -- DOES NOT RETURN.
 function quit(first, ...)
 	local rest = {...}
+	for i = 1, select("#", ...) do
+		assert(rest[i] ~= nil)
+	end
+
 	for i = 1, #rest do
 		if type(rest[i]) == "number" then
 			rest[i] = tostring(rest[i])

--- a/src/compiler.lua
+++ b/src/compiler.lua
@@ -38,6 +38,7 @@ function quit(first, ...)
 		if type(rest[i]) == "number" then
 			rest[i] = tostring(rest[i])
 		elseif type(rest[i]) ~= "string" then
+			assert(rest[i] ~= nil, "rest[i] ~= nil")
 			if not rest[i].ends then
 				print(...)
 			end

--- a/src/def.lua
+++ b/src/def.lua
@@ -258,7 +258,6 @@ EXTEND_TYPE("MatchSt", "AbstractStatementIR", recordType {
 	tag = constantType "match",
 	base = "VariableIR",
 	cases = listType(recordType {
-		variable = "VariableIR",
 		variant = "string",
 		statement = "StatementIR",
 	}),

--- a/src/def.lua
+++ b/src/def.lua
@@ -87,7 +87,7 @@ REGISTER_TYPE("Signature", recordType {
 	longName = "string",
 
 	parameters = listType "VariableIR",
-	returnTypes = listType "Type+",
+	returnTypes = listType "TypeKind",
 	modifier = choiceType(constantType "static", constantType "method"),
 	foreign = "boolean",
 	bang = "boolean",
@@ -359,7 +359,7 @@ EXTEND_TYPE("ForallSt", "AbstractStatementIR", recordType {
 
 REGISTER_TYPE("VariableIR", recordType {
 	name = "string",
-	type = "Type+",
+	type = "TypeKind",
 	location = "Location",
 	description = choiceType(constantType(false), "string"),
 })

--- a/src/def.lua
+++ b/src/def.lua
@@ -266,10 +266,10 @@ EXTEND_TYPE("MatchSt", "AbstractStatementIR", recordType {
 
 EXTEND_TYPE("IsASt", "AbstractStatementIR", recordType {
 	tag = constantType "isa",
+	variant = "string",
 	base = "VariableIR",
 	destination = "VariableIR",
 	returns = constantType "no",
-	variant = "string",
 })
 
 EXTEND_TYPE("ForallSt", "AbstractStatementIR", recordType {

--- a/src/def.lua
+++ b/src/def.lua
@@ -124,14 +124,11 @@ REGISTER_TYPE("AbstractStatementIR", recordType {
 
 EXTEND_TYPE("AssumeSt", "AbstractStatementIR", recordType {
 	tag = constantType "assume",
-	body = "nil",
 	variable = "VariableIR",
-	location = "Location",
 })
 
 EXTEND_TYPE("VerifySt", "AbstractStatementIR", recordType {
 	tag = constantType "verify",
-	body = "nil",
 	variable = "VariableIR",
 	checkLocation = "Location",
 	conditionLocation = "Location",

--- a/src/def.lua
+++ b/src/def.lua
@@ -77,7 +77,7 @@ REGISTER_TYPE("FunctionIR", recordType {
 	parameters = listType "VariableIR",
 	generics = listType "TypeParameterIR",
 	returnTypes = listType "Type+",
-	body = choiceType(constantType(false), "BlockSt"),
+	body = choiceType(constantType(false), "StatementIR"),
 	signature = "Signature",
 	definitionName = "string",
 })
@@ -91,8 +91,8 @@ REGISTER_TYPE("Signature", recordType {
 	modifier = choiceType(constantType "static", constantType "method"),
 	foreign = "boolean",
 	bang = "boolean",
-	requiresAST = listType "ASTExpression",
-	ensuresAST = listType "ASTExpression",
+	requiresASTs = listType "ASTExpression",
+	ensuresASTs = listType "ASTExpression",
 	logic = choiceType(
 		constantType(false),
 		mapType("boolean", listType(listType(choiceType("boolean", constantType "*"))))
@@ -111,21 +111,19 @@ REGISTER_TYPE("maybe", choiceType(constantType "yes", constantType "no", constan
 REGISTER_TYPE("StatementIR", intersectType("AbstractStatementIR", choiceType(
 	-- Execution
 	"AssignSt",
-	"BlockSt",
+	"SequenceSt",
 	"BooleanLoadSt",
 	"FieldSt",
-	"GenericMethodCallSt",
-	"GenericStaticCallSt",
+	"DynamicCallSt",
+	"StaticCallSt",
 	"IsASt",
 	"LocalSt",
 	"MatchSt",
-	"MethodCallSt",
 	"NewClassSt",
 	"NewUnionSt",
 	"IntLoadSt",
 	"ReturnSt",
 	"IfSt",
-	"StaticCallSt",
 	"StringLoadSt",
 	"ThisSt",
 	"UnitSt",
@@ -169,13 +167,13 @@ EXTEND_TYPE("ProofSt", "AbstractStatementIR", recordType {
 	returns = constantType "no",
 })
 
-EXTEND_TYPE("BlockSt", "AbstractStatementIR", recordType {
-	tag = constantType "block",
+EXTEND_TYPE("SequenceSt", "AbstractStatementIR", recordType {
+	tag = constantType "sequence",
 	statements = listType "StatementIR",
 })
 
 EXTEND_TYPE("StringLoadSt", "AbstractStatementIR", recordType {
-	tag = constantType "string",
+	tag = constantType "string-load",
 	destination = "VariableIR",
 	string = "string",
 	returns = constantType "no",
@@ -213,7 +211,7 @@ EXTEND_TYPE("IfSt", "AbstractStatementIR", recordType {
 })
 
 EXTEND_TYPE("IntLoadSt", "AbstractStatementIR", recordType {
-	tag = constantType "int",
+	tag = constantType "int-load",
 	number = "number",
 	destination = "VariableIR",
 	returns = constantType "no",
@@ -243,31 +241,14 @@ EXTEND_TYPE("NewUnionSt", "AbstractStatementIR", recordType {
 
 EXTEND_TYPE("StaticCallSt", "AbstractStatementIR", recordType {
 	tag = constantType "static-call",
-	constraints = mapType("string", "ConstraintIR"),
-	baseType = "Type+",
 	arguments = listType "VariableIR",
 	destinations = listType "VariableIR",
 	returns = constantType "no",
 	signature = "Signature",
-
-	-- XXX: delete this
-	staticName = "nil",
 })
 
-EXTEND_TYPE("MethodCallSt", "AbstractStatementIR", recordType {
-	tag = constantType "method-call",
-	baseInstance = "VariableIR",
-	arguments = listType "VariableIR",
-	destinations = listType "VariableIR",
-	returns = constantType "no",
-	signature = "Signature",
-
-	-- XXX: delete
-	methodName = "nil",
-})
-
-EXTEND_TYPE("GenericMethodCallSt", "AbstractStatementIR", recordType {
-	tag = constantType "generic-method-call",
+EXTEND_TYPE("DynamicCallSt", "AbstractStatementIR", recordType {
+	tag = constantType "dynamic-call",
 	baseInstance = "VariableIR",
 	constraint = "ConstraintIR",
 	arguments = listType "VariableIR",
@@ -277,18 +258,6 @@ EXTEND_TYPE("GenericMethodCallSt", "AbstractStatementIR", recordType {
 
 	-- XXX: delete this
 	methodName = "nil",
-})
-
-EXTEND_TYPE("GenericStaticCallSt", "AbstractStatementIR", recordType {
-	tag = constantType "generic-static-call",
-	constraint = "ConstraintIR",
-	arguments = listType "VariableIR",
-	destinations = listType "VariableIR",
-	returns = constantType "no",
-	signature = "Signature",
-
-	-- XXX: delete this
-	staticName = "nil",
 })
 
 EXTEND_TYPE("BooleanLoadSt", "AbstractStatementIR", recordType {
@@ -360,8 +329,6 @@ EXTEND_TYPE("ForallSt", "AbstractStatementIR", recordType {
 REGISTER_TYPE("VariableIR", recordType {
 	name = "string",
 	type = "TypeKind",
-	location = "Location",
-	description = choiceType(constantType(false), "string"),
 })
 
 REGISTER_TYPE("ConstraintIR", choiceType(

--- a/src/def.lua
+++ b/src/def.lua
@@ -83,6 +83,7 @@ REGISTER_TYPE("FunctionIR", recordType {
 })
 
 REGISTER_TYPE("Signature", recordType {
+	-- TODO: Do we need memberName?
 	memberName = "string",
 	longName = "string",
 
@@ -220,23 +221,16 @@ EXTEND_TYPE("IntLoadSt", "AbstractStatementIR", recordType {
 EXTEND_TYPE("NewClassSt", "AbstractStatementIR", recordType {
 	tag = constantType "new-class",
 	fields = mapType("string", "VariableIR"),
-	type = "ConcreteType+",
-	constraints = mapType("string", "ConstraintIR"),
 	destination = "VariableIR",
 	returns = constantType "no",
-	memberDefinitions = mapType("string", "VariableIR"),
-	location = "Location",
 })
 
 EXTEND_TYPE("NewUnionSt", "AbstractStatementIR", recordType {
 	tag = constantType "new-union",
-	type = "ConcreteType+",
 	field = "string",
 	value = "VariableIR",
-	constraints = mapType("string", "ConstraintIR"),
 	destination = "VariableIR",
 	returns = constantType "no",
-	variantDefinition = "VariableIR",
 })
 
 EXTEND_TYPE("StaticCallSt", "AbstractStatementIR", recordType {
@@ -273,7 +267,6 @@ EXTEND_TYPE("FieldSt", "AbstractStatementIR", recordType {
 	base = "VariableIR",
 	destination = "VariableIR",
 	returns = constantType "no",
-	fieldDefinition = "VariableIR",
 })
 
 EXTEND_TYPE("ThisSt", "AbstractStatementIR", recordType {
@@ -294,7 +287,6 @@ EXTEND_TYPE("VariantSt", "AbstractStatementIR", recordType {
 	base = "VariableIR",
 	variant = "string",
 	returns = constantType "no",
-	variantDefinition = "VariableIR",
 })
 
 EXTEND_TYPE("MatchSt", "AbstractStatementIR", recordType {

--- a/src/def.lua
+++ b/src/def.lua
@@ -22,13 +22,14 @@ REGISTER_TYPE("Token", recordType {
 REGISTER_TYPE("Semantics", recordType {
 	compounds = listType(recordType {
 		tag = choiceType(constantType("union-definition"), constantType("class-definition")),
-		fieldMap = mapType("string", recordType {
+		_fieldMap = mapType("string", recordType {
 			name = "string",
 			type = "TypeKind",
 		}),
 		constraintArguments = listType(recordType {
 			name = "string",
-			index = "integer",
+			concerningIndex = "integer",
+			constraintListIndex = "integer",
 			constraint = "ConstraintKind",
 		}),
 		fullName = "string",
@@ -41,12 +42,13 @@ REGISTER_TYPE("Semantics", recordType {
 REGISTER_TYPE("InterfaceIR", recordType {
 	tag = constantType "interface-definition",
 	fullName = "string",
-	functionMap = mapType("string", recordType {
+	_functionMap = mapType("string", recordType {
 		signature = "Signature",
 	}),
 	constraintArguments = listType(recordType {
 		name = "string",
-		index = "integer",
+		concerningIndex = "integer",
+		constraintListIndex = "integer",
 		constraint = "ConstraintKind",
 	}),
 })
@@ -259,6 +261,7 @@ EXTEND_TYPE("MatchSt", "AbstractStatementIR", recordType {
 	tag = constantType "match",
 	base = "VariableIR",
 	cases = listType(recordType {
+		variable = "VariableIR",
 		variant = "string",
 		statement = "StatementIR",
 	}),
@@ -299,7 +302,7 @@ REGISTER_TYPE("VTableIR", choiceType(
 		tag = constantType "concrete-vtable",
 		interface = "ConstraintKind",
 		concrete = "TypeKind",
-		arguments = mapType("string", listType "VTableIR"),
+		arguments = listType "VTableIR",
 	}
 ))
 

--- a/src/def.lua
+++ b/src/def.lua
@@ -20,7 +20,7 @@ REGISTER_TYPE("Token", recordType {
 -- Type Definitions ------------------------------------------------------------
 
 REGISTER_TYPE("Semantics", recordType {
-	classes = listType "ClassIR",
+	compounds = listType(choiceType("ClassIR", "UnionIR")),
 	interfaces = listType "InterfaceIR",
 	builtins = listType(recordType {
 		tag = constantType "builtin",
@@ -28,7 +28,6 @@ REGISTER_TYPE("Semantics", recordType {
 		signatures = listType "Signature",
 		type = "KeywordType+",
 	}),
-	unions = listType "UnionIR",
 	functions = listType "FunctionIR",
 	main = choiceType("string", constantType(false)),
 })
@@ -387,38 +386,55 @@ REGISTER_TYPE("ConstraintIR", choiceType(
 
 --------------------------------------------------------------------------------
 
-REGISTER_TYPE("Type+", choiceType("ConcreteType+", "KeywordType+", "GenericType+", "SelfType+"))
+REGISTER_TYPE("Kind", choiceType("TypeKind", "ConstraintKind"))
 
-REGISTER_TYPE("InterfaceType+", recordType {
-	tag = constantType "interface-type",
-	name = "string",
-	arguments = listType "Type+",
-	location = "Location",
+REGISTER_TYPE("TypeKind", choiceType(
+	"CompoundTypeKind",
+	"SelfTypeKind",
+	"GenericTypeKind",
+	"KeywordTypeKind"
+))
+
+REGISTER_TYPE("CompoundTypeKind", recordType {
+	tag = constantType "compound-type",
+	role = constantType "type",
+	packageName = "string",
+	definitionName = "string",
+	arguments = listType("TypeKind"),
 })
 
-REGISTER_TYPE("ConcreteType+", recordType {
-	tag = constantType "concrete-type+",
-	name = "string",
-	arguments = listType "Type+",
-	location = "Location",
+REGISTER_TYPE("SelfTypeKind", recordType {
+	tag = constantType "self-type",
+	role = constantType "type",
 })
 
-REGISTER_TYPE("KeywordType+", recordType {
-	tag = constantType "keyword-type+",
+REGISTER_TYPE("GenericTypeKind", recordType {
+	tag = constantType "generic-type",
+	role = constantType "type",
 	name = "string",
-	location = "Location",
 })
 
-REGISTER_TYPE("GenericType+", recordType {
-	tag = constantType "generic+",
-
-	-- e.g., "Foo" for `#Foo`
+REGISTER_TYPE("KeywordTypeKind", recordType {
+	tag = constantType "keyword-type",
+	role = constantType "type",
 	name = "string",
-
-	location = "Location",
 })
 
-REGISTER_TYPE("SelfType+", recordType {
-	tag = constantType "self-type+",
-	location = "Location",
+REGISTER_TYPE("ConstraintKind", choiceType(
+	"InterfaceConstraintKind",
+	"KeywordConstraintKind"
+))
+
+REGISTER_TYPE("InterfaceConstraintKind", recordType {
+	tag = constantType "interface-constraint",
+	role = constantType "constraint",
+	packageName = "string",
+	definitionName = "string",
+	arguments = listType("TypeKind"),
+})
+
+REGISTER_TYPE("KeywordConstraintKind", recordType {
+	tag = constantType "keyword-constraint",
+	role = constantType "constraint",
+	name = "string",
 })

--- a/src/semantic-errors.lua
+++ b/src/semantic-errors.lua
@@ -167,7 +167,7 @@ function Report.INTERFACE_REQUIRES_MEMBER(p)
 	quit(
 		"The class/union `",
 		p.class,
-		"` claims to implement interface",
+		"` claims to implement the interface",
 		" `",
 		p.interface,
 		"` ",

--- a/src/semantic-errors.lua
+++ b/src/semantic-errors.lua
@@ -564,4 +564,13 @@ function Report.QUANTIFIER_USED_IN_IMPLEMENTATION(p)
 	)
 end
 
+function Report.RECURSIVE_REQUIRES(p)
+	quit(
+		"The preconditions of `",
+		p.func,
+		"` are recursive ",
+		p.location
+	)
+end
+
 return Report

--- a/src/semantic-errors.lua
+++ b/src/semantic-errors.lua
@@ -538,6 +538,10 @@ function Report.INEXHAUSTIVE_MATCH(p)
 	)
 end
 
+function Report.CANNOT_USE_RETURN(p)
+	quit("The `return` expression cannot be used ", p.location)
+end
+
 function Report.RETURN_USED_IN_IMPLEMENTATION(p)
 	quit(
 		"The `return` keyword can only be used as an expression in",

--- a/src/semantic-errors.lua
+++ b/src/semantic-errors.lua
@@ -452,11 +452,10 @@ function Report.THIS_USED_OUTSIDE_METHOD(p)
 	quit("You try to use `this` in a non-method function ", p.location)
 end
 
---------------------------------------------------------------------------------
 
 function Report.CONFLICTING_INTERFACES(p)
 	quit(
-		"The method `",
+		"The call `",
 		p.method,
 		"` is ambiguous ",
 		p.location,
@@ -470,32 +469,7 @@ function Report.CONFLICTING_INTERFACES(p)
 	)
 end
 
-function Report.TYPE_MUST_BE_CLASS(p)
-	assertis(p.purpose, "string")
-	assertis(p.givenType, "string")
-	assertis(p.location, "Location")
-
-	quit(
-		"The ",
-		p.purpose,
-		" must be a class instance. However, it is a ",
-		p.givenType,
-		" ",
-		p.location
-	)
-end
-
-function Report.TYPE_MUST_BE_UNION(p)
-	quit(
-		"The ",
-		p.purpose,
-		" must be a union instance. However, you try to use a ",
-		"`",
-		p.givenType,
-		"` ",
-		p.location
-	)
-end
+--------------------------------------------------------------------------------
 
 function Report.FUNCTION_DOESNT_RETURN(p)
 	quit(

--- a/src/semantic-errors.lua
+++ b/src/semantic-errors.lua
@@ -163,9 +163,6 @@ function Report.VARIABLE_DEFINED_TWICE(p)
 	)
 end
 
---------------------------------------------------------------------------------
-
-
 function Report.INTERFACE_REQUIRES_MEMBER(p)
 	quit(
 		"The class/union `",
@@ -179,11 +176,55 @@ function Report.INTERFACE_REQUIRES_MEMBER(p)
 		" member `" .. p.memberName .. "` which is required by the interface `",
 		p.interface,
 		"` ",
-		p.memberLocation
+		p.interfaceLocation
 	)
 end
 
-function Report.INTERFACE_REQUIRES_MODIFIER(p)
+function Report.INTERFACE_MODIFIER_MISMATCH(p)
+	quit(
+		"The class/union `",
+		p.class,
+		"` claims to implement interface",
+		" `",
+		p.interface,
+		"` ",
+		p.claimLocation,
+		"\nThe interface `",
+		p.interface,
+		"` defines a ",
+		p.interfaceModifier,
+		" member called `",
+		p.memberName,
+		"` ",
+		p.interfaceLocation,
+		"\nHowever, `",
+		p.class,
+		"` defines `",
+		p.memberName,
+		"` to be a ",
+		p.classModifier,
+		" ",
+		p.classLocation
+	)
+end
+
+function Report.INTERFACE_BANG_MISMATCH(p)
+	quit(
+		"The class/union `",
+		p.class,
+		"` claims to implement interface `",
+		p.interface,
+		"` ",
+		p.claimLocation,
+		"\nHowever, `" .. p.class .. "` implements the ",
+		p.modifier,
+		"`" .. p.memberName .. "` ",
+		not p.expectedBang and "with" or "without",
+		" an action `!`, which disagrees with the interface."
+	)
+end
+
+function Report.INTERFACE_COUNT_MISMATCH(p)
 	quit(
 		"The class/union `",
 		p.class,
@@ -194,137 +235,59 @@ function Report.INTERFACE_REQUIRES_MODIFIER(p)
 		"\nThe interface `",
 		p.interface,
 		"` defines a ",
-		p.interfaceModifier,
-		" member called `",
-		p.name,
-		"` ",
-		p.interfaceLocation,
-		"\nHowever, `",
-		p.class,
-		"` defines `",
-		p.name,
-		"` to be a ",
-		p.classModifier,
-		" ",
-		p.classLocation
-	)
-end
-
-function Report.INTERFACE_PARAMETER_COUNT_MISMATCH(p)
-	quit(
-		"The class/union `",
-		p.class,
-		"` claims to implement interface",
-		" `",
-		p.interface,
-		"`.",
-		"\nThe interface `",
-		p.interface,
-		"` defines a member called `",
-		p.name,
+		p.modifier,
+		" called `",
+		p.memberName,
 		"` with ",
 		p.interfaceCount,
-		" parameter(s) ",
+		" " .. p.thing .. "(s) ",
 		p.interfaceLocation,
 		"\nHowever, `",
 		p.class,
 		"` defines `",
-		p.name,
+		p.memberName,
 		"` with ",
 		p.classCount,
-		" parameter(s)",
+		" " .. p.thing .. "(s) ",
 		p.classLocation
 	)
 end
 
-function Report.INTERFACE_PARAMETER_TYPE_MISMATCH(p)
+function Report.INTERFACE_TYPE_MISMATCH(p)
 	quit(
 		"The class/union `",
 		p.class,
 		"` claims to implement interface",
 		" `",
 		p.interface,
-		"`.",
+		"` ",
+		p.claimLocation,
 		"\nThe interface `",
 		p.interface,
-		"` defines a member called `",
-		p.name,
+		"` defines a ",
+		p.modifier,
+		" called `",
+		p.memberName,
 		"` with the ",
 		string.ordinal(p.index),
-		" parameter of type `",
+		" " .. p.thing .. " of type `",
 		p.interfaceType,
 		"` ",
 		p.interfaceLocation,
 		"\nHowever, `",
 		p.class,
 		"` defines `",
-		p.name,
+		p.memberName,
 		"` with the ",
 		string.ordinal(p.index),
-		" parameter of type `",
+		" " .. p.thing .." of type `",
 		p.classType,
 		"` ",
 		p.classLocation
 	)
 end
 
-function Report.INTERFACE_RETURN_COUNT_MISMATCH(p)
-	quit(
-		"The class/union `",
-		p.class,
-		"` claims to implement interface",
-		" `",
-		p.interface,
-		"`.",
-		"\nThe interface `",
-		p.interface,
-		"` defines a member called `",
-		p.member,
-		"` with ",
-		p.interfaceCount,
-		" return value(s) ",
-		p.interfaceLocation,
-		"\nHowever, `",
-		p.class,
-		"` defines `",
-		p.member,
-		"` with ",
-		p.classCount,
-		" return values(s) ",
-		p.classLocation
-	)
-end
-
-function Report.INTERFACE_RETURN_TYPE_MISMATCH(p)
-	quit(
-		"The class/union `",
-		p.class,
-		"` claims to implement interface",
-		" `",
-		p.interface,
-		"`.",
-		"\nThe interface `",
-		p.interface,
-		"` defines a member called `",
-		p.member,
-		"` with the ",
-		string.ordinal(p.index),
-		" return-value of type `",
-		p.interfaceType,
-		"` ",
-		p.interfaceLocation,
-		"\nHowever, `",
-		p.class,
-		"` defines `",
-		p.member,
-		"` with the ",
-		string.ordinal(p.index),
-		" return-value of type `",
-		p.classType,
-		"` ",
-		p.classLocation
-	)
-end
+--------------------------------------------------------------------------------
 
 function Report.VARIABLE_DEFINITION_COUNT_MISMATCH(p)
 	quit(

--- a/src/semantic-errors.lua
+++ b/src/semantic-errors.lua
@@ -298,14 +298,14 @@ end
 function Report.TYPE_MISMATCH(p)
 	quit(
 		"The " .. p.purpose,
-		" should be ",
+		" expects a value of type `",
 		p.expected,
-		" as defined ",
+		"` as defined ",
 		p.expectedLocation,
 		"\nHowever, the " .. p.purpose,
-		" was ",
+		" was `",
 		p.given,
-		" ",
+		"` ",
 		p.givenLocation
 	)
 end
@@ -502,6 +502,12 @@ function Report.UNKNOWN_OPERATOR_USED(p)
 end
 
 function Report.VARIANT_USED_TWICE(p)
+	assertis(p, recordType {
+		variant = "string",
+		firstLocation = "Location",
+		secondLocation = "Location",
+	})
+
 	quit(
 		"You use the variant `case ",
 		p.variant,

--- a/src/semantic-errors.lua
+++ b/src/semantic-errors.lua
@@ -350,20 +350,41 @@ function Report.NO_SUCH_MEMBER(p)
 	)
 end
 
---------------------------------------------------------------------------------
-
-
-
-function Report.NO_SUCH_VARIANT(p)
+function Report.BANG_NOT_ALLOWED(p)
 	quit(
-		"The type `",
-		p.container,
-		"` does not have a variant called `",
-		p.name,
-		"`",
-		"\nHowever, you try to access variant `",
-		p.name,
-		"` ",
+		"A `!` action is not allowed in ",
+		p.context,
+		".",
+		"\nHowever, you try to invoke one ",
+		p.location
+	)
+end
+
+function Report.BANG_MISMATCH(p)
+	assert(p.given ~= p.expected)
+
+	local expects
+	local given
+	if p.expected then
+		expects = "a `!` " .. p.modifier .. " action"
+		given = "without a `!`"
+	else
+		expects = "a pure (no `!`) " .. p.modifier
+		given = "with a `!`"
+	end
+
+	quit(
+		"The ",
+		p.modifier,
+		" ",
+		p.fullName,
+		" is defined to be ",
+		expects,
+		" ",
+		p.signatureLocation,
+		"\nHowever, you try to call it ",
+		given,
+		" ",
 		p.location
 	)
 end
@@ -372,26 +393,66 @@ function Report.NO_SUCH_VARIABLE(p)
 	quit("There is no variable named `", p.name, "` in scope ", p.location)
 end
 
-function Report.NO_SUCH_METHOD(p)
+function Report.NEW_IN_INTERFACE(p)
 	quit(
-		"The type `",
-		p.type,
-		"` does not have a ",
-		p.modifier,
-		" called `",
-		p.name,
-		"`.",
-		"\nAvailable members include ",
-		"\n\t",
-		table.concat(p.alternatives, ", "),
-		"\nHowever, you try to call `",
-		p.type,
-		".",
-		p.name,
-		"` ",
+		"Interfaces do not have constructors.\n",
+		"However, you try to use `new()` ",
 		p.location
 	)
 end
+
+function Report.DUPLICATE_INITIALIZATION(p)
+	if p.first == p.second then
+		quit("The ", p.purpose, " is initialized twice ", p.location)
+	end
+	quit(
+		"The ",
+		p.purpose,
+		" is initialized twice. The first initialization is ",
+		p.first,
+		"\nThe second initialization is ",
+		p.second
+	)
+end
+
+function Report.MISSING_INITIALIZATION(p)
+	quit(
+		"The ",
+		p.purpose,
+		" is never initialized ",
+		p.location
+	)
+end
+
+function Report.WRONG_VALUE_COUNT(p)
+	quit(
+		"Expected ",
+		p.expectedCount,
+		" ",
+		p.purpose,
+		" but got ",
+		p.givenCount,
+		" ",
+		p.givenLocation
+	)
+end
+
+function Report.TYPE_MUST_BE(p)
+	quit(
+		"The type `",
+		p.givenType,
+		"` cannot be used as ",
+		p.purpose,
+		" as it is ",
+		p.givenLocation
+	)
+end
+
+function Report.THIS_USED_OUTSIDE_METHOD(p)
+	quit("You try to use `this` in a non-method function ", p.location)
+end
+
+--------------------------------------------------------------------------------
 
 function Report.CONFLICTING_INTERFACES(p)
 	quit(
@@ -436,18 +497,6 @@ function Report.TYPE_MUST_BE_UNION(p)
 	)
 end
 
-function Report.MISSING_VALUE(p)
-	quit(
-		"The ",
-		p.purpose,
-		" requires a value for field `",
-		p.name,
-		"`.",
-		"\nHowever, it is missing ",
-		p.location
-	)
-end
-
 function Report.FUNCTION_DOESNT_RETURN(p)
 	quit(
 		"The ",
@@ -457,45 +506,6 @@ function Report.FUNCTION_DOESNT_RETURN(p)
 		" does not always `return` ",
 		p.returns,
 		" as it says it does ",
-		p.location
-	)
-end
-
-function Report.BANG_MISMATCH(p)
-	assert(p.given ~= p.expected)
-
-	local expects
-	local given
-	if p.expected then
-		expects = "a `!` " .. p.modifier .. " action"
-		given = "without a `!`"
-	else
-		expects = "a pure (no `!`) " .. p.modifier
-		given = "with a `!`"
-	end
-
-	quit(
-		"The ",
-		p.modifier,
-		" ",
-		p.fullName,
-		" is defined to be ",
-		expects,
-		" ",
-		p.signatureLocation,
-		"\nHowever, you try to call it ",
-		given,
-		" ",
-		p.location
-	)
-end
-
-function Report.BANG_NOT_ALLOWED(p)
-	quit(
-		"A `!` action is not allowed in ",
-		p.context,
-		".",
-		"\nHowever, you try to invoke one ",
 		p.location
 	)
 end
@@ -524,10 +534,6 @@ function Report.UNKNOWN_OPERATOR_USED(p)
 		"` ",
 		p.location
 	)
-end
-
-function Report.THIS_USED_OUTSIDE_METHOD(p)
-	quit("You try to use `this` in a non-method function ", p.location)
 end
 
 function Report.VARIANT_USED_TWICE(p)
@@ -579,15 +585,6 @@ function Report.QUANTIFIER_USED_IN_IMPLEMENTATION(p)
 		"\nHowever, you use `",
 		p.quantifier,
 		"` ",
-		p.location
-	)
-end
-
-
-function Report.USE_NEW_IN_INTERFACE(p)
-	quit(
-		"Interfaces do not have constructors.\n",
-		"However, you try to use `new()` ",
 		p.location
 	)
 end

--- a/src/semantic-errors.lua
+++ b/src/semantic-errors.lua
@@ -296,34 +296,18 @@ function Report.UNREACHABLE_STATEMENT(p)
 end
 
 function Report.TYPE_MISMATCH(p)
-	if #p.given ~= #p.expected then
-		quit(
-			"There were " .. #p.expected .. " " .. p.purpose .. " expected",
-			" ",
-			p.expectedLocation,
-			"\nHowever, " .. #p.given .. " " .. p.purpose .. " were supplied ",
-			p.givenLocation
-		)
-	end
-
-	for i in ipairs(p.given) do
-		if p.given[i] ~= p.expected[i] then
-			quit(
-				"The " .. string.ordinal(i) .. " " .. p.purpose,
-				" should be ",
-				p.expected[i],
-				" as defined ",
-				p.expectedLocation,
-				"\nHowever, the " .. string.ordinal(i) .. " " .. p.purpose,
-				" was ",
-				p.given[i],
-				" ",
-				p.givenLocation
-			)
-		end
-	end
-
-	error "unreachable"
+	quit(
+		"The " .. p.purpose,
+		" should be ",
+		p.expected,
+		" as defined ",
+		p.expectedLocation,
+		"\nHowever, the " .. p.purpose,
+		" was ",
+		p.given,
+		" ",
+		p.givenLocation
+	)
 end
 
 function Report.EVALUATION_ORDER(p)
@@ -472,6 +456,13 @@ end
 --------------------------------------------------------------------------------
 
 function Report.FUNCTION_DOESNT_RETURN(p)
+	assertis(p, recordType {
+		modifier = "string",
+		name = "string",
+		returns = "string",
+		location = "Location",
+	})
+
 	quit(
 		"The ",
 		p.modifier,

--- a/src/semantic-errors.lua
+++ b/src/semantic-errors.lua
@@ -140,8 +140,6 @@ function Report.TYPE_MUST_IMPLEMENT_CONSTRAINT(p)
 	)
 end
 
---------------------------------------------------------------------------------
-
 function Report.MEMBER_DEFINED_TWICE(p)
 	quit(
 		"The member `" .. p.name .. "` was already defined ",
@@ -151,6 +149,21 @@ function Report.MEMBER_DEFINED_TWICE(p)
 	)
 end
 
+function Report.VARIABLE_DEFINED_TWICE(p)
+	quit(
+		"The variable `",
+		p.name,
+		"` is first defined ",
+		p.first,
+		"While it is still in scope, you attempt to define another variable ",
+		"with the same name `",
+		p.name,
+		"` ",
+		p.second
+	)
+end
+
+--------------------------------------------------------------------------------
 
 
 function Report.INTERFACE_REQUIRES_MEMBER(p)
@@ -320,20 +333,6 @@ function Report.VARIABLE_DEFINITION_COUNT_MISMATCH(p)
 		p.variableCount,
 		" variable(s) are defined ",
 		p.location
-	)
-end
-
-function Report.VARIABLE_DEFINED_TWICE(p)
-	quit(
-		"The variable `",
-		p.name,
-		"` is first defined ",
-		p.first,
-		"While it is still in scope, you attempt to define another variable ",
-		"with the same name `",
-		p.name,
-		"` ",
-		p.second
 	)
 end
 

--- a/src/semantic-errors.lua
+++ b/src/semantic-errors.lua
@@ -287,93 +287,72 @@ function Report.INTERFACE_TYPE_MISMATCH(p)
 	)
 end
 
---------------------------------------------------------------------------------
-
-function Report.VARIABLE_DEFINITION_COUNT_MISMATCH(p)
+function Report.UNREACHABLE_STATEMENT(p)
 	quit(
-		p.valueCount,
-		" value(s) are provided but ",
-		p.variableCount,
-		" variable(s) are defined ",
+		"Statements following a `return` can never be reached.",
+		"\nThis makes an unreachable point in your code ",
 		p.location
 	)
 end
 
-function Report.WRONG_VALUE_COUNT(p)
+function Report.TYPE_MISMATCH(p)
+	if #p.given ~= #p.expected then
+		quit(
+			"There were " .. #p.expected .. " " .. p.purpose .. " expected",
+			" ",
+			p.expectedLocation,
+			"\nHowever, " .. #p.given .. " " .. p.purpose .. " were supplied ",
+			p.givenLocation
+		)
+	end
+
+	for i in ipairs(p.given) do
+		if p.given[i] ~= p.expected[i] then
+			quit(
+				"The " .. string.ordinal(i) .. " " .. p.purpose,
+				" should be ",
+				p.expected[i],
+				" as defined ",
+				p.expectedLocation,
+				"\nHowever, the " .. string.ordinal(i) .. " " .. p.purpose,
+				" was ",
+				p.given[i],
+				" ",
+				p.givenLocation
+			)
+		end
+	end
+
+	error "unreachable"
+end
+
+function Report.EVALUATION_ORDER(p)
 	quit(
-		"The ",
-		p.purpose,
-		" needs ",
-		p.expectedCount,
-		" value(s),",
-		" but was given ",
-		p.givenCount,
-		" ",
-		p.location
+		"The evaluation order of an expressions.",
+		"\nThe first is ",
+		p.first,
+		"\nThe second is ",
+		p.second
 	)
 end
 
-function Report.TYPES_DONT_MATCH(p)
-	assertis(p.expectedType, "string")
-	assertis(p.givenType, "string")
-	assertis(p.location, "Location")
-	assertis(p.purpose, "string")
-	quit(
-		"The ",
-		p.purpose,
-		" expects `",
-		p.expectedType,
-		"` as defined ",
-		p.expectedLocation,
-		"\nHowever, you pass a `",
-		p.givenType,
-		"` ",
-		p.location
-	)
-end
-
-function Report.EXPECTED_DIFFERENT_TYPE(p)
-	assertis(p.expectedType, "string")
-	assertis(p.givenType, "string")
-	assertis(p.location, "Location")
-	assertis(p.purpose, "string")
-	quit(
-		"The ",
-		p.purpose,
-		" expects `",
-		p.expectedType,
-		"` but was given `",
-		p.givenType,
-		"` ",
-		p.location
-	)
-end
-
-function Report.EQ_TYPE_MISMATCH(p)
-	quit(
-		"The operands of `==` must be of the same type.",
-		"\nHowever, the left operand to `==` is of type `",
-		p.leftType,
-		"` while the right operand is of type `",
-		p.rightType,
-		"` ",
-		p.location
-	)
-end
-
-function Report.NO_SUCH_FIELD(p)
+function Report.NO_SUCH_MEMBER(p)
 	quit(
 		"The type `",
 		p.container,
-		"` does not have a field called `",
+		"` does not have a " .. p.memberType .. " called `",
 		p.name,
 		"`",
-		"\nHowever, you try to access `",
+		"\nHowever, you try to use `",
 		p.name,
 		"` ",
 		p.location
 	)
 end
+
+--------------------------------------------------------------------------------
+
+
 
 function Report.NO_SUCH_VARIANT(p)
 	quit(
@@ -604,9 +583,6 @@ function Report.QUANTIFIER_USED_IN_IMPLEMENTATION(p)
 	)
 end
 
-function Report.EVALUATION_ORDER(p)
-	quit("The evaluation order of an expression is not defined ", p.location)
-end
 
 function Report.USE_NEW_IN_INTERFACE(p)
 	quit(

--- a/src/semantics.lua
+++ b/src/semantics.lua
@@ -11,3737 +11,591 @@ local variableDescription = common.variableDescription
 local BOOLEAN_DEF = table.findwith(common.BUILTIN_DEFINITIONS, "name", "Boolean")
 local UNKNOWN_LOCATION = freeze {begins = "???", ends = "???"}
 
--- RETURNS the clearest possible combination of a, and b.
-local function unclear(a, b)
-	assertis(a, "maybe")
-	assertis(b, "maybe")
-	if a == b then
-		return a
-	end
-	return "maybe"
-end
+-- RETURNS a description of the given TypeKind as a string of Smol code
+local function showTypeKind(t)
+	assertis(t, "TypeKind")
 
--- RETURNS a string of smol representing the given interface type
-local function showInterfaceType(t)
-	assertis(t, "InterfaceType+")
-
-	if #t.arguments == 0 then
+	if t.tag == "compound-type" then
+		local base = t.packageName .. ":" .. t.definitionName
+		if #t.arguments == 0 then
+			return base
+		end
+		local arguments = table.map(showTypeKind, t.arguments)
+		return base .. "[" .. table.concat(arguments, ", ") .. "]"
+	elseif t.tag == "self-type" then
+		return "#Self"
+	elseif t.tag == "generic-type" then
+		return "#" .. t.name
+	elseif t.tag == "keyword-type" then
 		return t.name
 	end
-	local arguments = table.map(showType, t.arguments)
-	return t.name .. "[" .. table.concat(arguments, ", ") .. "]"
+	error "unknown TypeKind tag"
 end
 
-local idCount = 0
+-- RETURNS a description of the given ConstraintKind as a string of Smol code
+local function showConstraintKind(c)
+	assertis(c, "ConstraintKind")
 
--- RETURNS a unique (to this struct) local variable name
-local function generateLocalID(hint)
-	idCount = idCount + 1
-	local indicator = string.char(string.byte "A" + (idCount - 1) % 26)
-	return "_local" .. indicator .. tostring(idCount) .. "_" .. tostring(hint)
-end
-
--- RETURNS a LocalSt
-local function localSt(variable)
-	assertis(variable, "VariableIR")
-
-	return freeze {
-		tag = "local",
-		variable = variable,
-		returns = "no",
-	}
-end
-
--- RETURNS VariableIR, LocalSt
-local function generateVariable(nameHint, type, location)
-	assertis(nameHint, "string")
-	assertis(type, "Type+")
-	assertis(location, "Location")
-
-	local variable = freeze {
-		name = generateLocalID(nameHint),
-		type = type,
-		location = location,
-		description = false,
-	}
-	return variable, localSt(variable)
-end
-
--- RETURNS a StatementIR representing the execution of statements in
--- sequence
-local function buildBlock(statements)
-	assertis(statements, listType(recordType {}))
-
-	-- Blocks have absolutely no meaning (in terms of scope, etc):
-	-- Blocks ONLY group statements into a single statement for constructs that
-	-- require it.
-	-- For cleanliness, blocks-of-blocks are flattened.
-	-- However, this is NOT to be taken as a guarantee that blocks will never
-	-- contain blocks as children.
-	local flattenList = {}
-	local flatten = false
-	for _, s in ipairs(statements) do
-		assertis(s, "StatementIR")
-		if s.tag == "block" then
-			for _, c in ipairs(s.statements) do
-				table.insert(flattenList, c)
-			end
-			flatten = true
-		else
-			table.insert(flattenList, s)
+	if c.tag == "interface-constraint" then
+		local base = c.packageName .. ":" .. c.definitionName
+		if #c.arguments == 0 then
+			return base
 		end
+		local arguments = table.map(showTypeKind, c.arguments)
+		return base .. "[" .. table.concat(arguments, ", ") .. "]"
+	elseif c.tag == "keyword-constraint" then
+		return c.name
 	end
-	if flatten then
-		return buildBlock(flattenList)
-	end
-
-	local returned = "no"
-	for i, statement in ipairs(statements) do
-		if statement.returns == "yes" then
-			assert(i == #statements)
-			returned = "yes"
-		elseif statement.returns == "maybe" then
-			returned = "maybe"
-		end
-	end
-
-	return freeze {
-		tag = "block",
-		returns = returned,
-		statements = statements,
-	}
+	error "unknown ConstraintKind tag"
 end
 
--- RETURNS a StatementIR representing the same execution, but to be ignored by
--- codegeneration
-local function buildProof(statement)
-	assertis(statement, "StatementIR")
+-- RETURNS a Kind with the same structure, buch each GenericTypeKind replaced
+-- with a TypeKind from the map
+-- REQUIRES each GenericTypeKind mentioned by the kind is present in the map
+local function substituteGenerics(kind, map)
+	assertis(kind, "Kind")
+	assertis(map, mapType("string", "TypeKind"))
+	
+	if kind.tag == "generic-type" then
+		assert(map[kind.name])
+		return map[kind.name]
+	elseif kind.tag == "compound-type" then
+		return {
+			tag = "compound-type",
+			role = "type",
+			packageName = kind.packageName,
+			definitionName = kind.definitionName,
+			arguments = table.map(substituteGenerics, kind.arguments, map),
+		}
+	elseif kind.tag == "interface-constraint" then
+		return {
+			tag = "interface-constraint",
+			role = "constraint",
+			packageName = kind.packageName,
+			definitionName = kind.definitionName,
+			arguments = table.map(substituteGenerics, kind.arguments, map),
+		}
+	elseif kind.tag == "self-type" then
+		error "TODO: How should #Self be substitute?"
+	end
 
-	return freeze {
-		tag = "proof",
-		body = statement,
-		returns = "no",
-	}
+	-- All other Kinds are non-recursive
+	return kind
 end
 
--- assignments: map string -> Type+
--- RETURNS a function Type+ -> Type+ that substitutes the indicated
--- types for generic variables.
-local function genericSubstituter(assignments)
-	assertis(assignments, mapType("string", "Type+"))
-
-	-- Self is a keyword; here is refers to the (more) concrete type that
-	-- implements this interface
-	assert(assignments.Self, "assignments.Self must be provided to genericSubstituer")
-
-	local function subs(t)
-		assertis(t, choiceType("InterfaceType+", "Type+"))
-
-		if t.tag == "interface-type" then
-			return {
-				tag = "interface-type",
-				name = t.name,
-				arguments = table.map(subs, t.arguments),
-				location = t.location,
-			}
-		elseif t.tag == "concrete-type+" then
-			return {
-				tag = "concrete-type+",
-				name = t.name,
-				arguments = table.map(subs, t.arguments),
-				location = t.location,
-			}
-		elseif t.tag == "keyword-type+" then
-			return t
-		elseif t.tag == "generic+" then
-			if not assignments[t.name] then
-				-- XXX: should this be an assert?
-				Report.UNKNOWN_GENERIC_USED(t)
-			end
-			return assignments[t.name]
-		elseif t.tag == "self-type+" then
-			return assignments.Self
-		end
-		error("unknown Type+ tag `" .. t.tag .. "`")
-	end
-	return subs
+-- RETURNS whether or not the ConstraintKind a is satisfied by the
+-- ConstraintKind b.
+-- NOTE: As Smol is currently designed, this only happens when a and b are the
+-- same constraint
+local function constraintSatisfiedBy(a, b)
+	return showConstraintKind(a) == showConstraintKind(b)
 end
 
---------------------------------------------------------------------------------
-
--- RETURNS a function Type+ -> Type+ to apply to types on the in interface's
--- definition to get specific types for a given instantiation
-local function getSubstituterFromInterface(int, selfType, allDefinitions)
-	assertis(int, "InterfaceType+")
-	assertis(allDefinitions, listType "Definition")
-	assertis(selfType, "Type+")
-
-	local definition = table.findwith(allDefinitions, "name", int.name)
-	assert(definition)
-	assert(#definition.generics == #int.arguments)
-
-	-- Note that "Self" is a keyword, so it is not a valid generic name
-	local assignments = {Self = selfType}
-	for i, generic in ipairs(definition.generics) do
-		assignments[generic.name] = int.arguments[i]
-	end
-	return genericSubstituter(assignments)
-end
-
--- RETURNS a function Type+ -> Type+ to apply to types on the
--- class/union's definition to use the specific types
--- in this instance
-local function getSubstituterFromConcreteType(type, allDefinitions)
-	assertis(type, "Type+")
-	assertis(allDefinitions, listType "Definition")
-
-	if type.tag == "keyword-type+" then
-		return genericSubstituter({Self = type})
-	end
-	assertis(type, "ConcreteType+")
-
-	local definition = table.findwith(allDefinitions, "name", type.name)
-	assert(definition)
-	assert(#definition.generics == #type.arguments)
-
-	local assignments = {Self = type}
-	for i, generic in ipairs(definition.generics) do
-		assignments[generic.name] = type.arguments[i]
-	end
-	return genericSubstituter(assignments)
-end
-
--- RETURNS a list of constraints (as InterfaceType+) that the given type
--- satisfies
-local function getTypeConstraints(type, typeScope, allDefinitions)
-	assertis(type, "Type+")
-	assertis(typeScope, listType "TypeParameterIR")
-	assertis(allDefinitions, listType "Definition")
-
-	if type.tag == "concrete-type+" then
-		local definition = table.findwith(allDefinitions, "name", type.name)
-		assert(definition and #definition.generics == #type.arguments)
-
-		local substitute = getSubstituterFromConcreteType(type, allDefinitions, type)
-		local constraints = table.map(substitute, definition.implements)
-		return constraints
-	elseif type.tag == "keyword-type+" then
-		-- XXX: Right now, keyword types do not implement any interfaces,
-		-- requiring explicit boxing
-		return {}
-	elseif type.tag == "generic+" then
-		local parameter = table.findwith(typeScope, "name", type.name)
-		assert(parameter)
-
-		return table.map(table.getter "interface", parameter.constraints)
-	end
-	error("unknown Type+ tag `" .. type.tag .. "`")
-end
-
---------------------------------------------------------------------------------
-
--- RETURNS nothing
--- VERIFIES that the type satisfies the required constraint
-local function verifyTypeSatisfiesConstraint(type, constraint, typeScope, need, allDefinitions)
-	assertis(type, "Type+")
-	assertis(constraint, "InterfaceType+")
-	assertis(typeScope, listType "TypeParameterIR")
-	assertis(need, recordType {
-		container = "Definition",
-		constraint = "InterfaceType+",
-		nth = "integer",
+-- RETURNS a resolving function (TypeAST => Kind)
+-- The produced Kinds are fully valid: The referred types exist; they are used
+-- with the correct arity; their arguments satisfy the correct constraints
+-- REQUIRES definitionMap is finished
+-- REQUIRES importsByName does not conflict with source's set of definitions,
+-- and that there are no duplicate names in the set of definitions of a package
+-- REQUIRES the return not be invoked until a resolver is made for each
+-- definition in the map
+local function makeDefinitionASTResolver(info, definitionMap)
+	assertis(info, recordType {
+		packageName = "string",
+		importsByName = mapType("string", recordType {
+			packageName = "string",
+			definitionName = choiceType(constantType(false), "string"),
+		}),
 	})
-	assertis(allDefinitions, listType "Definition")
+	assertis(definitionMap, mapType("string", mapType("string", recordType {})))
 
-	for _, c in ipairs(getTypeConstraints(type, typeScope, allDefinitions)) do
-		if areInterfaceTypesEqual(c, constraint) then
-			return
-		end
-	end
-
-	-- The type `type` does not implement the constraint `constraint`
-	Report.TYPE_MUST_IMPLEMENT_CONSTRAINT {
-		type = showType(type),
-		constraint = showInterfaceType(constraint),
-		location = type.location,
-
-		nth = need.nth,
-		container = need.container.name,
-		cause = need.constraint.location,
+	local shortNameMap = {}
+	local usePackages = {
+		[info.packageName] = info.source.package.location,
 	}
-end
 
--- RETURNS nothing
--- VERIFIES that the type is entirely valid (in terms of scope, arity,
--- and constraints)
-local function verifyTypeValid(type, typeScope, allDefinitions)
-	assertis(type, "Type+")
-	assertis(typeScope, listType "TypeParameterIR")
-	assertis(allDefinitions, listType "Definition")
+	-- Check that all imports are valid and mark which short names can be used
+	for key, importAST in pairs(info.importsByName) do
+		if importAST.definitionName then
+			assert(not shortNameMap[importAST.definitionName])
 
-	if type.tag == "concrete-type+" then
-		local definition = table.findwith(allDefinitions, "name", type.name)
-		local substitute = getSubstituterFromConcreteType(type, allDefinitions)
-
-		-- Check each argument
-		for i, generic in ipairs(definition.generics) do
-			local argument = type.arguments[i]
-			assertis(argument, "Type+")
-
-			-- Verify that the `i`th argument satisfies the constraints of
-			-- the `i`th parameter
-			for _, generalConstraint in ipairs(generic.constraints) do
-				local instantiatedConstraint = substitute(generalConstraint.interface)
-
-				-- TODO: better explain context
-				verifyTypeSatisfiesConstraint(
-					argument,
-					instantiatedConstraint,
-					typeScope,
-					{
-						container = definition,
-						constraint = generalConstraint.interface,
-						nth = i,
-					},
-					allDefinitions
-				)
-			end
-
-			-- Verify recursively
-			verifyTypeValid(argument, typeScope, allDefinitions)
-		end
-	elseif type.tag == "keyword-type+" then
-		-- All keyword types are valid
-		return
-	elseif type.tag == "generic+" then
-		-- All generic literals are valid
-		return
-	elseif type.tag == "self-type+" then
-		-- All #Self literals are valid
-		-- TODO: Though perhaps they should be forbidden in classes/unions
-		return
-	else
-		error("unknown Type+ tag `" .. type.tag .. "`")
-	end
-end
-
--- RETURNS nothing
-local function verifyInterfaceValid(constraint, typeScope, allDefinitions)
-	assertis(constraint, "InterfaceType+")
-	assertis(typeScope, listType "TypeParameterIR")
-	assertis(allDefinitions, listType "Definition")
-
-	local definition = table.findwith(allDefinitions, "name", constraint.name)
-	assert(definition.tag == "interface")
-
-	local SELF_TYPE = freeze {tag = "self-type+", location = constraint.location}
-	local substitute = getSubstituterFromInterface(constraint, SELF_TYPE, allDefinitions)
-
-	-- Check each argument
-	for i, generic in ipairs(definition.generics) do
-		local argument = constraint.arguments[i]
-		assertis(argument, "Type+")
-
-		-- Verify that the i-th argument satisfies the constraints of the i-th
-		-- parameter
-		for _, generalConstraint in ipairs(generic.constraints) do
-			local instantiatedConstraint = substitute(generalConstraint.interface)
-
-			-- TODO: provide a clearer context for error messages
-			verifyTypeSatisfiesConstraint(
-				argument,
-				instantiatedConstraint,
-				typeScope,
-				{
-					container = definition,
-					constraint = generalConstraint.interface,
-					nth = i,
-				},
-				allDefinitions
-			)
-		end
-
-		-- Verify each argument in a recursive fashion
-		verifyTypeValid(argument, typeScope, allDefinitions)
-	end
-end
-
---------------------------------------------------------------------------------
-
--- RETURNS a variable or nil
-local function getFromScope(scope, name)
-	assertis(scope, listType(mapType("string", "object")))
-	assertis(name, "string")
-
-	for i = #scope, 1, -1 do
-		if scope[i][name] then
-			return scope[i][name]
-		end
-	end
-	return nil
-end
-
---------------------------------------------------------------------------------
-
-local STRING_TYPE = common.STRING_TYPE
-local INT_TYPE = common.INT_TYPE
-local BOOLEAN_TYPE = common.BOOLEAN_TYPE
-local UNIT_TYPE = common.UNIT_TYPE
-local NEVER_TYPE = common.NEVER_TYPE
-
-local BUILTIN_DEFINITIONS = common.BUILTIN_DEFINITIONS
-local OPERATOR_ALIAS = common.OPERATOR_ALIAS
-
---------------------------------------------------------------------------------
-
--- RETURNS a Definition
-local function interfaceDefinitionFromConstraint(t, allDefinitions)
-	assertis(t, "InterfaceType+")
-	assertis(allDefinitions, listType "Definition")
-
-	local definition = table.findwith(allDefinitions, "name", t.name)
-	assert(definition and definition.tag == "interface")
-
-	return definition
-end
-
--- RETURNS a Definition
-local function definitionFromType(t, allDefinitions)
-	assertis(t, choiceType("ConcreteType+", "KeywordType+"))
-	assertis(allDefinitions, listType(recordType {name = "string"}))
-
-	if t.tag == "keyword-type+" then
-		local builtin = table.findwith(BUILTIN_DEFINITIONS, "name", t.name)
-		assert(builtin)
-		return builtin
-	end
-
-	local definition = table.findwith(allDefinitions, "name", t.name)
-
-	-- Type Finder should verify that the type exists
-	assert(definition, "definition must exist")
-
-	return definition
-end
-
---------------------------------------------------------------------------------
-
--- RETURNS record with interface, signature, constraint, name, etc.
-local function findConstraintByMember(genericType, modifier, name, location, generics, environment)
-	assertis(genericType, "GenericType+")
-	assertis(modifier, choiceType(constantType "static", constantType "method"))
-	assertis(name, "string")
-	assertis(location, "Location")
-	assert(name:sub(1, 1):lower() == name:sub(1, 1))
-	assertis(generics, listType "TypeParameterIR")
-
-	assertis(environment, recordType {
-		allDefinitions = listType "Definition",
-		containingSignature = "Signature",
-		thisVariable = choiceType(constantType(false), "VariableIR"),
-	})
-
-	local parameter, pi = table.findwith(generics, "name", genericType.name)
-	assertis(parameter, recordType {
-		location = "Location",
-	})
-
-	local matches = {}
-	for ci, constraint in ipairs(parameter.constraints) do
-		local interface = interfaceDefinitionFromConstraint(constraint.interface, environment.allDefinitions)
-		local signature = table.findwith(interface.signatures, "memberName", name)
-		if signature then
-			local constraintIR = {
-				tag = "parameter-constraint",
-				name = "#" .. pi .. "_" .. ci,
-				location = constraint.location,
-				interface = constraint.interface,
-			}
-			if environment.containingSignature.modifier == "method" then
-				assert(environment.thisVariable)
-				constraintIR = {
-					tag = "this-constraint",
-					instance = table.with(environment.thisVariable, "location", location),
-					name = "#" .. pi .. "_" .. ci,
-					interface = constraint.interface,
+			-- Check if such a definition really exists
+			if not definitionMap[importAST.packageName][importAST.definitionName] then
+				Report.UNKNOWN_DEFINITION_IMPORTED {
+					name = importAST.packageName .. ":" .. importAST.definitionName,
+					location = importAST.location,
 				}
 			end
 
-			table.insert(matches, freeze {
-				signature = signature,
-				interface = interface,
-				constraint = constraint.interface,
-				constraintIR = constraintIR,
-			})
+			-- Remember the short name
+			shortNameMap[importAST.definitionName] = {
+				package = importAST.packageName,
+				name = importAST.definitionName,
+			}
+		else
+			-- Check if such a package really exists
+			if usePackages[importAST.packageName] then
+				Report.IMPORT_PACKAGE_TWICE {
+					packageName = importAST.packageName,
+					firstLocation = usePackages[importAST.packageName],
+					secondLocation = importAST.location,
+				}
+			end
+
+			-- Mark the package as usable
+			usePackages[importAST.packageName] = importAST.location
 		end
 	end
 
-	-- Verify exactly one constraint supplies this method name
-	if #matches == 0 then
-		-- TODO: get alternatives
-		local alternatives = {"???"}
-
-		Report.NO_SUCH_METHOD {
-			modifier = modifier,
-			type = showType(genericType),
-			name = name,
-			definitionLocation = parameter.location,
-			location = location,
-			alternatives = alternatives,
-		}
-	elseif #matches > 1 then
-		Report.CONFLICTING_INTERFACES {
-			method = name,
-			interfaceOne = showType(matches[1].interface),
-			interfaceTwo = showType(matches[2].interface),
-			location = location,
+	-- Get a list of short names for all members of this package
+	for key, definition in pairs(definitionMap[info.packageName]) do
+		assert(not shortNameMap[key])
+		shortNameMap[key] = {
+			package = info.packageName,
+			name = key,
 		}
 	end
 
-	-- Verify the method's modifier matches
-	local method = matches[1]
-	if method.signature.modifier ~= modifier then
-		Report.WRONG_MODIFIER {
-			signatureModifier = method.signature.modifier,
-			signatureLocation = method.signature.location,
-			callModifier = modifier,
-			location = location,
-		}
+	-- RETURNS nothing
+	-- REQUIRES arguments be all TypeKinds and correct arity
+	-- REQUIRES resolvers be set for all the definitions
+	local function checkRequirements(arguments, package, name)
+		assertis(arguments, listType "TypeKind")
+		assertis(package, "string")
+		assertis(name, "string")
+
+		local definition = definitionMap[package][name]
+		assert(definition and #definition.definition.generics == #arguments)
+
 	end
 
-	assertis(method, recordType {
-		interface = "InterfaceIR",
-		signature = "Signature",
-		constraint = "InterfaceType+",
-		constraintIR = "ConstraintIR",
-	})
-	return method
-end
+	-- RETURNS a completely valid Kind, when the constraints inserted to the
+	-- list are met (up to meeting constraints when context.checkConstraints is
+	-- false)
+	local function resolver(ast, context)
+		assertis(ast, recordType {
+			tag = "string",
+		})
 
--- generics: the generics IN SCOPE, not the generics of interface/implementer.
--- RETURNS a ConstraintIR
-local function constraintFromStruct(interface, implementer, generics, containingSignature, environment, location)
-	assertis(interface, "InterfaceType+")
-	assertis(implementer, "Type+")
-	assertis(generics, listType "TypeParameterIR")
-	assertis(containingSignature, "Signature")
-	assertis(environment, recordType {
-		allDefinitions = listType "object",
-		thisVariable = choiceType(constantType(false), "VariableIR"),
-	})
-	assertis(location, "Location")
+		assertis(context, recordType {
+			selfAllowed = choiceType(constantType(false), "InterfaceConstraintKind"),
 
-	if implementer.tag == "concrete-type+" then
-		local definition = definitionFromType(implementer, environment.allDefinitions)
+			-- Whether or not to check if types have the constraints they need
+			-- for this kind to be valid
+			checkConstraints = "boolean",
+
+			generics = "object",
+		})
+		if context.checkConstraints then
+			assertis(context.generics, recordType {
+				order = listType "string",
+				map = mapType("string", listType(recordType {
+					constraint = "ConstraintKind",
+					location = "Location",
+				})),
+				locations = mapType("string", "Location"),
+			})
+		else
+			assertis(context.generics, mapType("string", "Location"))
+		end
+
+		-- Handle non-recursive type ASTs
+		if ast.tag == "type-keyword" then
+			return {
+				tag = "keyword-type",
+				role = "type",
+				name = ast.name,
+			}
+		elseif ast.tag == "generic" then
+			return {
+				tag = "generic-type",
+				role = "type",
+				name = ast.name,
+			}
+		elseif ast.tag == "keyword-generic" then
+			assert(ast.name == "Self")
+
+			-- Check that #Self is only used inside interfaces
+			if not context.selfAllowed then
+				Report.SELF_OUTSIDE_INTERFACE {
+					location = ast.location,
+				}
+			end
+
+			return {
+				tag = "self-type",
+				role = "type",
+			}
+		end
+		
+		assertis(ast, recordType {
+			tag = constantType("concrete-type"),
+			package = choiceType(constantType(false), "string"),
+			base = "string",
+			arguments = "object",
+		})
+
+		local packageName, definitionName
+		if not ast.package then
+			-- Check that the short name alias is available
+			if not shortNameMap[ast.base] then
+				Report.UNKNOWN_DEFINITION_USED {
+					name = ast.base,
+					location = ast.location,
+				}
+			end
+
+			packageName = shortNameMap[ast.base].package
+			definitionName = shortNameMap[ast.base].name
+		else
+			-- Check that such a package is in scope
+			if not usePackages[ast.package] then
+				Report.UNKNOWN_PACKAGE_USED {
+					package = ast.package,
+					location = ast.location,
+				}
+			end
+
+			-- Check that the definition exists
+			if not definitionMap[ast.package][ast.base] then
+				Report.UNKNOWN_DEFINITION_USED {
+					name = ast.package .. ":" .. ast.base,
+					location = ast.location,
+				}
+			end
+
+			packageName = ast.package
+			definitionName = ast.base
+		end
+
+		local definition = definitionMap[packageName][definitionName]
 		assert(definition)
 
-		-- Constraints of parameterized types depend on the constraints they
-		-- require
-		local assignments = {}
-		for i, generic in ipairs(definition.generics) do
-			for j, c in ipairs(generic.constraints) do
-				local key = "#" .. i .. "_" .. j
-
-				local interface = c.interface
-				assertis(interface, "InterfaceType+")
-
-				local implementer = implementer.arguments[i]
-				assertis(implementer, "Type+")
-
-				local constraint = constraintFromStruct(
-					interface,
-					implementer,
-					generics,
-					containingSignature,
-					environment,
-					location
-				)
-				assertis(constraint, "ConstraintIR")
-
-				assignments[key] = constraint
-			end
-		end
-
-		return freeze {
-			tag = "concrete-constraint",
-			interface = interface,
-			concrete = implementer,
-			assignments = assignments,
-		}
-	elseif implementer.tag == "generic+" then
-		local name
-		for i, generic in ipairs(generics) do
-			for j, c in ipairs(generic.constraints) do
-				if generic.name == implementer.name and c.interface.name == interface.name then
-					name = "#" .. i .. "_" .. j
-				end
-			end
-		end
-		assert(name)
-		if containingSignature.modifier == "static" then
-			-- Get a parameter constraint
-			return freeze {
-				tag = "parameter-constraint",
-				interface = interface,
-				name = name,
-			}
-		else
-			-- Get a this constraint
-			assert(environment.thisVariable)
-			return freeze {
-				tag = "this-constraint",
-				instance = table.with(environment.thisVariable, "location", location),
-				interface = interface,
-				name = name,
-			}
-		end
-	end
-	error("unhandled tag `" .. implementer.tag .. "`")
-end
-
---------------------------------------------------------------------------------
-
-local function checkSingleBoolean(vs, purpose, location)
-	assertis(vs, listType "VariableIR")
-	assertis(purpose, "string")
-
-	if #vs ~= 1 then
-		Report.WRONG_VALUE_COUNT {
-			purpose = purpose,
-			expectedCount = 1,
-			givenCount = #vs,
-			location = location or vs[1].location,
-		}
-	elseif not areTypesEqual(vs[1].type, BOOLEAN_TYPE) then
-		Report.EXPECTED_DIFFERENT_TYPE {
-			expectedType = "Boolean",
-			givenType = showType(vs[1].type),
-			location = location or vs[1].location,
-			purpose = purpose,
-		}
-	end
-end
-
---------------------------------------------------------------------------------
-
--- RETURNS whether or not the given parsed expression is pure (syntactically)
-local function isExprPure(expr)
-	local leaf = {
-		["string-literal"] = true,
-		["int-literal"] = true,
-		["identifier"] = true,
-		["keyword"] = true,
-	}
-	if leaf[expr.tag] then
-		return true
-	end
-
-	if expr.tag == "new-expression" then
-		for _, argument in ipairs(expr.arguments) do
-			if not isExprPure(argument.value) then
-				return false
-			end
-		end
-		return true
-	elseif expr.tag == "static-call" then
-		for _, argument in ipairs(expr.arguments) do
-			if not isExprPure(argument) then
-				return false
-			end
-		end
-		return not expr.bang
-	elseif expr.tag == "method-call" then
-		if not isExprPure(expr.base) then
-			return false
-		end
-		for _, argument in ipairs(expr.arguments) do
-			if not isExprPure(argument) then
-				return false
-			end
-		end
-		return not expr.bang
-	elseif expr.tag == "field" then
-		return isExprPure(expr.base)
-	elseif expr.tag == "binary" then
-		return isExprPure(expr.left) and isExprPure(expr.right)
-	elseif expr.tag == "isa" then
-		return isExprPure(expr.base)
-	elseif expr.tag == "forall-expr" then
-		-- The body of a forall is checked elsewhere; foralls never have side
-		-- effects since they are never run
-		return true
-	end
-	error("unknown tag `" .. expr.tag .. "`")
-end
-
-local compileExpression
-
--- conditionExpression: AST
--- thenBody: StatementIR
--- RETURNS StatementIR
-local function compileWhen(conditionExpression, thenBody, scope, subEnvironment)
-	assertis(thenBody, "StatementIR")
-
-	local conditionEval, conditionVars = compileExpression(
-		conditionExpression,
-		scope,
-		subEnvironment
-	)
-	checkSingleBoolean(conditionVars, "when")
-	assert(#conditionVars == 1)
-	assert(areTypesEqual(conditionVars[1].type, BOOLEAN_TYPE))
-
-	local assume = freeze {
-		tag = "assume",
-		variable = conditionVars[1],
-		location = conditionVars[1].location,
-		returns = "no",
-	}
-
-	local guarded = freeze {
-		tag = "if",
-		condition = conditionVars[1],
-		bodyThen = buildBlock {assume, thenBody},
-		bodyElse = buildBlock {},
-		returns = "no",
-	}
-
-	return buildBlock {
-		conditionEval,
-		guarded,
-	}
-end
-
--- RETURNS a ProofSt
--- REQUIRES assertion has already been checked for type and value count
-local function generatePreconditionVerify(assertion, method, invocation, environment, context, checkLocation)
-	assertis(assertion, recordType {
-		whens = listType "ASTExpression",
-		condition = "ASTExpression",
-	})
-	assertis(method, "Signature")
-	assertis(invocation, recordType {
-		arguments = listType "VariableIR",
-		container = "Type+",
-		this = choiceType(constantType(false), "VariableIR"),
-	})
-	assertis(environment, recordType {
-		returnOuts = choiceType(constantType(false), listType "VariableIR"),
-	})
-	assertis(context, "string")
-	assertis(checkLocation, "Location")
-
-	if invocation.this then
-		assert(areTypesEqual(invocation.this.type, invocation.container))
-	end
-
-	local subEnvironment = freeze {
-		resolveType = environment.resolveType,
-		containerType = invocation.container,
-		containingSignature = method,
-		allDefinitions = environment.allDefinitions,
-		thisVariable = invocation.this,
-		ignoreEnsures = environment.ignoreEnsures,
-
-		-- Can be not-false when checking `ensures` at `return` statement
-		returnOuts = environment.returnOuts,
-		verification = true,
-	}
-
-	local scope = {{}}
-	for i, argument in ipairs(invocation.arguments) do
-		scope[1][method.parameters[i].name] = argument
-	end
-	assertis(scope, listType(mapType("string", "VariableIR")))
-
-	-- Evaluate the condition
-	local evaluation, out = compileExpression(assertion.condition, scope, subEnvironment)
-	assert(#out == 1)
-	assert(areTypesEqual(out[1].type, BOOLEAN_TYPE))
-
-	local verify = freeze {
-		tag = "verify",
-		variable = out[1],
-		returns = "no",
-		reason = context,
-		conditionLocation = assertion.condition.location,
-		checkLocation = checkLocation,
-	}
-	local out = buildBlock {
-		evaluation,
-		verify,
-	}
-	assertis(out, "StatementIR")
-
-	-- Add a guard
-	for _, when in ripairs(assertion.whens) do
-		out = compileWhen(when, out, scope, subEnvironment)
-	end
-
-	return buildProof(out)
-end
-
--- RETURNS a ProofSt
--- REQUIRES assertion has already been checked for type and value count
-local function generatePostconditionAssume(assertion, method, invocation, environment, returnOuts)
-	assertis(assertion, recordType {
-		whens = listType "ASTExpression",
-		condition = "ASTExpression",
-	})
-	assertis(method, "Signature")
-	assertis(invocation, recordType {
-		arguments = listType "VariableIR",
-		this = choiceType(constantType(false), "VariableIR"),
-	})
-	assertis(environment, recordType {})
-	assertis(environment.containerType, "Type+")
-	assertis(returnOuts, choiceType(constantType(false), listType "VariableIR"))
-
-	local subEnvironment = {
-		resolveType = environment.resolveType,
-		containerType = invocation.container,
-		containingSignature = method,
-		containerType = environment.containerType,
-		allDefinitions = environment.allDefinitions,
-		thisVariable = invocation.this,
-		returnOuts = returnOuts,
-		ignoreEnsures = environment.ignoreEnsures,
-		verification = true,
-	}
-
-	-- Initialize the scope with just the arguments
-	local scope = {{}}
-	for i, argument in ipairs(invocation.arguments) do
-		scope[1][method.parameters[i].name] = argument
-	end
-	assertis(scope, listType(mapType("string", "VariableIR")))
-
-	local evaluation, out = compileExpression(assertion.condition, scope, subEnvironment)
-	assert(#out == 1)
-	assert(areTypesEqual(out[1].type, BOOLEAN_TYPE))
-
-	local assume = freeze {
-		tag = "assume",
-		variable = out[1],
-		returns = "no",
-		location = assertion.condition.location,
-	}
-
-	local out = buildBlock {
-		evaluation,
-		assume,
-	}
-	assertis(out, "StatementIR")
-
-	-- Add a guard
-	for _, when in ripairs(assertion.whens) do
-		out = compileWhen(when, out, scope, subEnvironment)
-	end
-
-	return buildProof(out)
-end
-
-local NOT_SIGNATURE = table.findwith(BOOLEAN_DEF.signatures, "memberName", "not")
-local OR_SIGNATURE = table.findwith(BOOLEAN_DEF.signatures, "memberName", "or")
-local AND_SIGNATURE = table.findwith(BOOLEAN_DEF.signatures, "memberName", "and")
-
--- RETURNS the string s if it contains only ASCII letters and digits
--- RETURNS s enclosed in ASCII round parenthesis otherwise
-local function parened(s)
-	assertis(s, "string")
-	if s:find "[^a-zA-Z0-9]" then
-		return "(" .. s .. ")"
-	end
-	return s
-end
-
--- RETURNS a StatementIR, VariableIR
-local function irMethod(location, signature, base, arguments)
-	assertis(location, "Location")
-	assertis(signature, "Signature")
-	assertis(base, "VariableIR")
-	assertis(arguments, listType "VariableIR")
-
-	assert(#signature.returnTypes == 1)
-
-	local result = generateVariable(
-		signature.longName .. "_result",
-		signature.returnTypes[1],
-		location
-	)
-	local d1 = variableDescription(base)
-	local ds = {}
-	for i = 1, #arguments do
-		ds[i] = variableDescription(arguments[i])
-	end
-	local description = parened(d1) .. "." .. signature.memberName .. "(" .. table.concat(ds, ", ") .. ")"
-	result = table.with(result, "description", description)
-	local method = freeze {
-		tag = "method-call",
-		baseInstance = base,
-		arguments = arguments,
-		destinations = {result},
-		signature = signature,
-		returns = "no",
-	}
-	return buildBlock {localSt(result), method}, result
-end
-
--- RETURNS an Assume that var is exactly one of the tags of union
-local function closedUnionAssumption(union, var)
-	assertis(var, "VariableIR")
-
-	local seq = {}
-	local ises = {}
-	for _, variant in ipairs(union.fields) do
-		local v = generateVariable("closed_union_is" .. variant.name, BOOLEAN_TYPE, var.location)
-		local description = parened(excerpt(var.location)) .. " is " .. variant.name
-		v = table.with(v, "description", description)
-
-		table.insert(ises, v)
-		table.insert(seq, localSt(v))
-		table.insert(seq, freeze {
-			tag = "isa",
-			base = var,
-			destination = v,
-			variant = variant.name,
-			returns = "no",
-		})
-	end
-
-	-- Generate any (is a or is b or is c ...)
-	local isAny = ises[1]
-	for i = 2, #ises do
-		local compute, nextIsAny = irMethod(var.location, OR_SIGNATURE, isAny, {ises[i]})
-		table.insert(seq, compute)
-		isAny = nextIsAny
-	end
-	local any = generateVariable("any-closed", BOOLEAN_TYPE, var.location)
-	any = table.with(any, "description", "???")
-	table.insert(seq, localSt(any))
-
-	table.insert(seq, {
-		tag = "assume",
-		variable = isAny,
-		location = var.location,
-		returns = "no",
-	})
-
-	return buildBlock(seq)
-end
-
--- RETURNS a StatementIR, [VariableIR].
--- The statement executes the expression, storing the results into the returned
--- variables.
--- VERIFIES each expression produces only a single value
--- VERIFIES at most one of the expressions is impure
-local function compileSubexpressions(expressions, purpose, location, scope, environment)
-	assertis(expressions, listType "ASTExpression")
-	assertis(location, "Location")
-	assertis(environment, recordType {})
-
-	local evaluation = {}
-	local outs = {}
-
-	local impures = 0
-	for i, expression in ipairs(expressions) do
-		local subEvaluation, subOuts = compileExpression(expression, scope, environment)
-		if #subOuts ~= 1 then
-			Report.WRONG_VALUE_COUNT {
-				purpose = string.ordinal(i) .. " " .. purpose,
-				expectedCount = 1,
-				givenCount = #subOuts,
-				location = expression.location,
-			}
-		end
-		table.insert(evaluation, subEvaluation)
-		table.insert(outs, subOuts[1])
-
-		if not isExprPure(expression) then
-			impures = impures + 1
-		end
-	end
-
-	if impures > 1 then
-		Report.EVALUATION_ORDER {
-			location = location,
-		}
-	end
-
-	return buildBlock(evaluation), freeze(outs)
-end
-
--- RETURNS a ProofSt assuming the `ensures` holds for the given function
--- invokation
-local function generateAssumeStatements(signature, info, environment)
-	assertis(signature, "Signature")
-	assertis(info, recordType {destinations = listType "VariableIR"})
-	assertis(environment, recordType {ignoreEnsures = mapType("string", "integer")})
-
-	if #signature.ensuresAST == 0 then
-		-- Nothing to be done
-		return buildBlock {}
-	end
-
-	local fullName = signature.longName
-	local depth = 0
-	if table.haskey(environment.ignoreEnsures, fullName) then
-		depth = environment.ignoreEnsures[fullName]
-	end
-
-	if depth >= 1 then
-		-- TODO: Skipping this ensure gives up some amount of completeness
-		return buildBlock {}
-	end
-
-	local evaluation = {}
-	for _, ensure in ipairs(signature.ensuresAST) do
-		local ignoreFurther = table.with(environment.ignoreEnsures, fullName, depth + 1)
-		local subEnvironment = table.with(environment, "ignoreEnsures", ignoreFurther)
-		local assumption = generatePostconditionAssume(
-			ensure,
-			signature,
-			{
-				arguments = info.arguments,
-				this = info.this,
-				container = info.container,
-			},
-			subEnvironment,
-			info.destinations
-		)
-		table.insert(evaluation, assumption)
-	end
-
-	return buildProof(buildBlock(evaluation))
-end
-
--- RETURNS StatementIR, [VariableIR] invoking a method
-local function compileMethod(baseInstance, arguments, methodName, bang, location, environment)
-	assertis(baseInstance, "VariableIR")
-	assertis(arguments, listType "VariableIR")
-	assertis(methodName, "string")
-	assertis(bang, "boolean")
-	assertis(location, "Location")
-	assertis(environment, recordType {})
-
-	local containerType = environment.containerType
-	local allDefinitions = environment.allDefinitions
-	local containingDefinition = definitionFromType(containerType, allDefinitions)
-	local containingSignature = environment.containingSignature
-
-	if baseInstance.type.tag == "generic+" then
-		-- Generic instance
-		local method = findConstraintByMember(
-			baseInstance.type,
-			"method",
-			methodName,
-			location,
-			containingDefinition.generics,
-			environment
-		)
-		assertis(method.signature, "Signature")
-
-		local substituter = getSubstituterFromInterface(
-			method.constraint,
-			baseInstance.type,
-			allDefinitions
-		)
-
-		local methodFullName = method.signature.longName
-
-		-- Verify the correct number of arguments is provided
-		if #arguments ~= #method.signature.parameters then
-			Report.WRONG_VALUE_COUNT {
-				purpose = "interface method `" .. methodFullName .. "`",
-				expectedCount = #method.signature.parameters,
-				givenCount = #arguments,
-				location = location,
-			}
-		end
-
-		-- Verify the types of the arguments match the parameters
-		for i, argument in ipairs(arguments) do
-			local expectedType = substituter(method.signature.parameters[i].type)
-			if not areTypesEqual(argument.type, expectedType) then
-				Report.TYPES_DONT_MATCH {
-					purpose = string.ordinal(i) .. " argument to `" .. methodFullName .. "`",
-					expectedType = showType(expectedType),
-					expectedLocation = method.signature.parameters[i].location,
-					givenType = showType(argument.type),
-					location = argument.location,
-				}
-			end
-		end
-
-		-- Verify the bang matches
-		if not method.signature.bang ~= not bang then
-			Report.BANG_MISMATCH {
-				modifier = method.signature.modifier,
-				fullName = methodFullName,
-				expected = method.signature.bang,
-				given = bang,
-				signatureLocation = method.signature.location,
-				location = location,
-			}
-		end
-
-		-- Create destinations for each return value
-		local evaluation = {}
-		local destinations = {}
-		for _, returnType in ipairs(method.signature.returnTypes) do
-			local destination = generateVariable("gm_return", substituter(returnType), location)
-			table.insert(destinations, destination)
-			table.insert(evaluation, localSt(destination))
-		end
-
-		-- Generate Verify statements
-		for i, require in ipairs(method.signature.requiresAST) do
-			local verification = generatePreconditionVerify(
-				require,
-				method.signature,
-				{arguments = arguments, this = baseInstance},
-				environment,
-				"the " .. string.ordinal(i) .. " `requires` condition for method " .. methodFullName,
-				location
-			)
-			table.insert(evaluation, verification)
-		end
-
-		local callSt = freeze {
-			tag = "generic-method-call",
-			baseInstance = baseInstance,
-			constraint = method.constraintIR,
-			arguments = arguments,
-			destinations = destinations,
-			returns = "no",
-			signature = method.signature,
-		}
-		assertis(callSt, "StatementIR")
-		table.insert(evaluation, callSt)
-
-		-- Generate Assume statements
-		local info = {
-			this = baseInstance,
-			arguments = arguments,
-			destinations = destinations,
-			container = baseInstance.type,
-		}
-		table.insert(evaluation, generateAssumeStatements(method.signature, info, environment))
-
-		return buildBlock(evaluation), freeze(destinations)
-	end
-
-	-- Concrete instance
-	local baseDefinition = definitionFromType(baseInstance.type, allDefinitions)
-	local substituter = getSubstituterFromConcreteType(baseInstance.type, allDefinitions)
-
-	-- Find the definition of the method being invoked
-	local method = table.findwith(baseDefinition.signatures, "memberName", methodName)
-	local alternatives = table.map(table.getter "memberName", baseDefinition.signatures)
-	if not method then
-		Report.NO_SUCH_METHOD {
-			type = showType(baseInstance.type),
-			modifier = "method",
-			name = methodName,
-			alternatives = alternatives,
-			location = location,
-		}
-	end
-	assertis(method, "Signature")
-
-	local methodFullName = method.longName
-	if not method or method.modifier ~= "method" then
-		Report.NO_SUCH_METHOD {
-			modifier = "method",
-			type = showType(baseInstance.type),
-			name = methodName,
-			definitionLocation = baseDefinition.location,
-			alternatives = alternatives,
-			location = location,
-		}
-	end
-
-	-- Verify the correct number of arguments is provided
-	if #arguments ~= #method.parameters then
-		Report.WRONG_VALUE_COUNT {
-			purpose = "method " .. methodFullName,
-			expectedCount = #method.parameters,
-			givenCount = #arguments,
-			location = location,
-		}
-	end
-
-	-- Verify the types of the arguments match the parameters
-	for i, argument in ipairs(arguments) do
-		if not areTypesEqual(argument.type, substituter(method.parameters[i].type)) then
-			Report.TYPES_DONT_MATCH {
-				purpose = string.ordinal(i) .. " argument to `" .. methodFullName .. "`",
-				expectedType = showType(method.parameters[i].type),
-				expectedLocation = method.parameters[i].location,
-				givenType = showType(argument.type),
-				location = argument.location,
-			}
-		end
-	end
-
-	-- Verify the bang matches
-	if not method.bang ~= not bang then
-		Report.BANG_MISMATCH {
-			modifier = method.modifier,
-			fullName = methodFullName,
-			expected = method.bang,
-			given = bang,
-			signatureLocation = method.location,
-			location = location,
-		}
-	elseif method.bang and not containingSignature.bang then
-		Report.BANG_NOT_ALLOWED {
-			context = containingSignature.modifier .. " `" .. containingSignature.longName .. "`",
-			location = location,
-		}
-	end
-
-	-- Create destinations for each return value
-	local evaluation = {}
-	local destinations = {}
-	for _, returnType in ipairs(method.returnTypes) do
-		local destination = generateVariable(
-			method.longName .. "_result",
-			substituter(returnType),
-			location
-		)
-		table.insert(destinations, destination)
-		table.insert(evaluation, localSt(destination))
-	end
-
-	-- Generate Verify statements
-	for i, require in ipairs(method.requiresAST) do
-		assert(baseInstance)
-		local verification = generatePreconditionVerify(
-			require,
-			method,
-			{arguments = arguments, this = baseInstance, container = baseInstance.type},
-			environment,
-			"the " .. string.ordinal(i) .. " `requires` condition for method " .. methodFullName,
-			location
-		)
-		table.insert(evaluation, verification)
-	end
-
-	table.insert(evaluation, {
-		tag = "method-call",
-		baseInstance = baseInstance,
-		arguments = arguments,
-		destinations = destinations,
-		returns = "no",
-		signature = method,
-	})
-
-	-- Generate Assume statements
-	local info = {
-		this = baseInstance,
-		arguments = arguments,
-		destinations = destinations,
-		container = baseInstance.type,
-	}
-	table.insert(evaluation, generateAssumeStatements(method, info, environment))
-
-	return buildBlock(evaluation), freeze(destinations)
-end
-
--- RETURNS StatementIR, [VariableIR]
-local function compileStatic(t, argumentSources, funcName, bang, location, environment)
-	assertis(t, "Type+")
-	assertis(argumentSources, listType "VariableIR")
-	assertis(funcName, "string")
-	assertis(bang, "boolean")
-	assertis(location, "Location")
-	assertis(environment, recordType {})
-
-	local allDefinitions = environment.allDefinitions
-	local containingSignature = environment.containingSignature
-	local containerType = environment.containerType
-	local containingDefinition = definitionFromType(containerType, allDefinitions)
-
-	if t.tag == "generic+" then
-		-- Generic static function
-		local static = findConstraintByMember(
-			t,
-			"static",
-			funcName,
-			t.location,
-			containingDefinition.generics,
-			environment
-		)
-		assert(static and static.signature.modifier == "static")
-		assertis(static.constraint, "InterfaceType+")
-
-		-- Map type variables to the type-values used for this instantiation
-		local substituter = getSubstituterFromInterface(static.constraint, t, allDefinitions)
-
-		local fullName = static.signature.longName
-
-		-- Check the number of parameters
-		if #argumentSources ~= #static.signature.parameters then
-			Report.WRONG_VALUE_COUNT {
-				purpose = "interface static `" .. fullName .. "`",
-				expectedCount = #static.signature.parameters,
-				givenCount = #argumentSources,
-				location = location,
-			}
-		end
-
-		-- Verify the argument types match the parameter types
-		for i, argument in ipairs(argumentSources) do
-			local parameterType = substituter(static.signature.parameters[i].type)
-			if not areTypesEqual(argument.type, parameterType) then
-				Report.TYPES_DONT_MATCH {
-					purpose = string.ordinal(i) .. " argument to `" .. fullName .. "`",
-					expectedLocation = static.signature.parameters[i].location,
-					givenType = showType(argument.type),
-					location = argument.location,
-					expectedType = showType(parameterType)
-				}
-			end
-		end
-
-		-- Create variables for the output
-		local evaluation = {}
-		local destinations = {}
-		for _, returnType in ipairs(static.signature.returnTypes) do
-			local returnVariable = generateVariable("gs_return", substituter(returnType), location)
-			table.insert(destinations, returnVariable)
-			table.insert(evaluation, localSt(returnVariable))
-		end
-
-		-- Verify the bang matches
-		if not static.signature.bang ~= not bang then
-			Report.BANG_MISMATCH {
-				modifier = static.signature.modifier,
-				fullName = fullName,
-				expected = static.signature.bang,
-				given = bang,
-				signatureLocation = static.signature.location,
-				location = location,
-			}
-		elseif static.signature.bang and not containingSignature.bang then
-			Report.BANG_NOT_ALLOWED {
-				context = containingSignature.modifier .. " " .. fullName,
-				location = location,
-			}
-		end
-
-		-- Generate Verify statements
-		for i, require in ipairs(static.signature.requiresAST) do
-			local verification = generatePreconditionVerify(
-				require,
-				static.signature,
-				{arguments = argumentSources, this = false},
-				environment,
-				"the " .. string.ordinal(i) .. " `requires` condition for static " .. fullName,
-				location
-			)
-			table.insert(evaluation, verification)
-		end
-
-		local callSt = {
-			tag = "generic-static-call",
-			constraint = static.constraintIR,
-			arguments = argumentSources,
-			destinations = destinations,
-			returns = "no",
-			signature = static.signature,
-		}
-		assertis(callSt, "StatementIR")
-		table.insert(evaluation, callSt)
-
-		-- Generate Assume statements
-		local info = {
-			this = false,
-			arguments = argumentSources,
-			destinations = destinations,
-			container = t,
-		}
-		table.insert(evaluation, generateAssumeStatements(static.signature, info, environment))
-
-		return buildBlock(evaluation), freeze(destinations)
-	end
-
-	local baseDefinition = definitionFromType(t, allDefinitions)
-
-	local fullName = showType(t) .. "." .. funcName
-
-	-- Map type variables to the type-values used for this instantiation
-	local substituter = getSubstituterFromConcreteType(t, allDefinitions)
-
-	local method = table.findwith(baseDefinition.signatures, "memberName", funcName)
-
-	if not method or method.modifier ~= "static" then
-		local alternatives = table.map(table.getter "memberName", baseDefinition.signatures)
-		Report.NO_SUCH_METHOD {
-			modifier = "static",
-			type = showType(t),
-			name = funcName,
-			definitionLocation = baseDefinition.location,
-			alternatives = alternatives,
-			location = location,
-		}
-	end
-
-	-- Check the number of parameters
-	if #method.parameters ~= #argumentSources then
-		Report.WRONG_VALUE_COUNT {
-			purpose = "static function `" .. fullName .. "`",
-			expectedCount = #method.parameters,
-			givenCount = #argumentSources,
-			location = location,
-		}
-	end
-
-	-- Verify the argument types match the parameter types
-	for i, argument in ipairs(argumentSources) do
-		local parameterType = substituter(method.parameters[i].type)
-		if not areTypesEqual(argument.type, parameterType) then
-			Report.TYPES_DONT_MATCH {
-				purpose = string.ordinal(i) .. " argument to " .. fullName,
-				expectedLocation = method.parameters[i].location,
-				givenType = showType(argument.type),
-				location = argument.location,
-				expectedType = showType(parameterType)
-			}
-		end
-	end
-
-	-- Collect the constraints
-	local constraints = {}
-	for gi, generic in ipairs(baseDefinition.generics) do
-		for ci, constraint in ipairs(generic.constraints) do
-			local key = "#" .. gi .. "_" .. ci
-			constraints[key] = constraintFromStruct(
-				constraint.interface,
-				t.arguments[gi],
-				containingDefinition.generics,
-				containingSignature,
-				environment,
-				constraint.location
-			)
-		end
-	end
-
-	-- Verify the bang matches
-	if not method.bang ~= not bang then
-		Report.BANG_MISMATCH {
-			modifier = method.modifier,
-			fullName = fullName,
-			expected = method.bang,
-			given = bang,
-			signatureLocation = method.location,
-			location = location,
-		}
-	elseif method.bang and not containingSignature.bang then
-		local fullName = containingSignature.longName
-		Report.BANG_NOT_ALLOWED {
-			context = containingSignature.modifier .. " " .. fullName,
-			location = location,
-		}
-	end
-
-	-- Create variables for the output
-	local evaluation = {}
-	local outs = {}
-	for _, returnType in ipairs(method.returnTypes) do
-		local returnVariable = generateVariable(
-			method.longName .. "_result",
-			substituter(returnType),
-			location
-		)
-		table.insert(outs, returnVariable)
-		table.insert(evaluation, localSt(returnVariable))
-	end
-
-	-- Generate Verify statements
-	for i, require in ipairs(method.requiresAST) do
-		local verification = generatePreconditionVerify(
-			require,
-			method,
-			{arguments = argumentSources, this = false, container = t},
-			environment,
-			"the " .. string.ordinal(i) .. " `requires` condition for static " .. fullName,
-			location
-		)
-		table.insert(evaluation, verification)
-	end
-
-	local call = {
-		tag = "static-call",
-		baseType = t,
-		arguments = argumentSources,
-		constraints = constraints,
-		destinations = outs,
-		returns = "no",
-		signature = method,
-	}
-	assertis(call, "StaticCallSt")
-	table.insert(evaluation, call)
-
-	-- Generate Assume statements
-	local info = {
-		this = false,
-		arguments = argumentSources,
-		destinations = outs,
-		container = t,
-	}
-	table.insert(evaluation, generateAssumeStatements(method, info, environment))
-
-	return buildBlock(evaluation), freeze(outs)
-end
-
--- RETURNS StatementIR, [Variable]
-function compileExpression(pExpression, scope, environment)
-	assertis(pExpression, recordType {tag = "string"})
-
-	--assertis(scope, listType(mapType("string", "VariableIR")))
-	assertis(environment, recordType {
-		resolveType = "function",
-		containerType = "Type+",
-		containingSignature = "Signature",
-		allDefinitions = listType "Definition",
-		thisVariable = choiceType(constantType(false), "VariableIR"),
-		ignoreEnsures = mapType("string", "integer"),
-		verification = "boolean",
-	})
-	local resolveType = environment.resolveType
-	local containerType = environment.containerType
-	local allDefinitions = environment.allDefinitions
-	local containingDefinition = definitionFromType(containerType, allDefinitions)
-	local containingSignature = environment.containingSignature
-
-	if pExpression.tag == "string-literal" then
-		local out, outDef = generateVariable("stringliteral", STRING_TYPE, pExpression.location)
-
-		local block = buildBlock {
-			outDef,
-			freeze {
-				tag = "string",
-				string = pExpression.value,
-				destination = out,
-				returns = "no",
-			},
-		}
-		return block, freeze {out}
-	elseif pExpression.tag == "int-literal" then
-		local out, outDef = generateVariable("intliteral", INT_TYPE, pExpression.location)
-
-		local block = buildBlock {
-			outDef,
-			{
-				tag = "int",
-				number = pExpression.value,
-				destination = out,
-				returns = "no",
-			}
-		}
-		return block, freeze {out}
-	elseif pExpression.tag == "new-expression" then
-		local location = pExpression.location
-
-		-- All of the constraints are provided as arguments to this
-		-- static function
-		local constraints = {}
-		for constraintName, interface in spairs(containingDefinition.constraints) do
-			constraints[constraintName] = freeze {
-				tag = "parameter-constraint",
-				name = constraintName,
-				location = location,
-				interface = interface,
-			}
-		end
-
-		local constituents = {}
-		for _, argument in ipairs(pExpression.arguments) do
-			table.insert(constituents, argument.value)
-		end
-		local subEvaluation, fieldValues = compileSubexpressions(
-			constituents,
-			"arguments to new " .. showType(containerType),
-			location,
-			scope,
-			environment
-		)
-
-		local map = {}
-		local memberDefinitions = {}
-		for i, value in ipairs(fieldValues) do
-			local pArgument = pExpression.arguments[i]
-			local fieldName = pArgument.name
-			local field = table.findwith(containingDefinition.fields, "name", fieldName)
-			if not field then
-				Report.NO_SUCH_FIELD {
-					name = fieldName,
-					container = showType(containerType),
-					location = pArgument.location,
+		-- Collect and validate the type-parameter arguments
+		local arguments = {}
+		for _, argumentAST in ipairs(ast.arguments) do
+			local argument = resolver(argumentAST, context)
+			
+			-- Check that the role of the argument is a type
+			if argument.role ~= "type" then
+				Report.INTERFACE_USED_AS_TYPE {
+					interface = showConstraintKind(argument),
+					location = argumentAST.location,
 				}
 			end
 
-			memberDefinitions[fieldName] = field
-			map[fieldName] = value
-
-			if not areTypesEqual(field.type, value.type) then
-				Report.TYPES_DONT_MATCH {
-					purpose = "field type",
-					expectedType = showType(field.type),
-					expectedLocation = field.location,
-					givenType = showType(value.type),
-					location = pArgument.location,
-				}
-			end
+			table.insert(arguments, argument)
 		end
 
-		local out = generateVariable("new", containerType, location)
-		local newSt = {
-			tag = "new-" .. containingDefinition.tag,
-			type = containerType,
-			returns = "no",
-			constraints = constraints,
-			destination = out,
-			location = location,
-		}
-
-		-- Record the map as fields
-		if containingDefinition.tag == "union" then
-			newSt.field, newSt.value = next(map)
-			newSt.variantDefinition = memberDefinitions[newSt.field]
-
-			-- Verify that exactly one field is given for union new
-			if #fieldValues ~= 1 then
-				Report.WRONG_VALUE_COUNT {
-					purpose = "new union field list",
-					expectedCount = 1,
-					givenCount = #fieldValues,
-					location = location,
-				}
-			end
-		elseif containingDefinition.tag == "class" then
-			newSt.fields = map
-			newSt.memberDefinitions = memberDefinitions
-
-			-- Check that no fields are missing for class new
-			for _, field in ipairs(containingDefinition.fields) do
-				if not newSt.fields[field.name] then
-					Report.MISSING_VALUE {
-						purpose = "new " .. showType(containerType) .. " expression",
-						name = field.name,
-						location = location,
-					}
-				end
-			end
-		end
-
-		local block = buildBlock {subEvaluation, localSt(out), newSt}
-		return block, freeze {out}
-	elseif pExpression.tag == "identifier" then
-		local block = buildBlock({})
-		local found = nil
-		for i = #scope, 1, -1 do
-			found = found or scope[i][pExpression.name]
-		end
-		if not found then
-			Report.NO_SUCH_VARIABLE {
-				name = pExpression.name,
-				location = pExpression.location,
-			}
-		end
-		local out = freeze {
-			name = found.name,
-			type = found.type,
-			location = pExpression.location,
-			description = false,
-		}
-		return block, freeze {out}
-	elseif pExpression.tag == "static-call" then
-		local t = resolveType(pExpression.baseType)
-		local n = pExpression.funcName
-		local location = pExpression.location
-
-		local argumentEvaluation, argumentSources = compileSubexpressions(
-			pExpression.arguments,
-			"argument to static " .. n,
-			location,
-			scope,
-			environment
-		)
-
-		local invocation, out = compileStatic(
-			t,
-			argumentSources,
-			n,
-			pExpression.bang,
-			location,
-			environment
-		)
-		return buildBlock {argumentEvaluation, invocation}, out
-	elseif pExpression.tag == "method-call" then
-		local n = pExpression.methodName
-		local location = pExpression.location
-
-		local subEvaluation, subSources = compileSubexpressions(
-			{pExpression.base, table.unpack(pExpression.arguments)},
-			"base/argument to method " .. n,
-			location,
-			scope,
-			environment
-		)
-
-		local baseInstance = subSources[1]
-		local arguments = table.rest(subSources, 2)
-
-		local call, out = compileMethod(
-			baseInstance,
-			arguments,
-			n,
-			pExpression.bang,
-			location,
-			environment
-		)
-		return buildBlock {subEvaluation, call}, out
-	elseif pExpression.tag == "keyword" then
-		if pExpression.keyword == "false" or pExpression.keyword == "true" then
-			local boolean = generateVariable("booleanliteral", BOOLEAN_TYPE, pExpression.location)
-			local execution = {
-				localSt(boolean),
-				{
-					tag = "boolean",
-					boolean = pExpression.keyword == "true",
-					destination = boolean,
-					returns = "no",
-				},
-			}
-			return buildBlock(execution), {boolean}
-		elseif pExpression.keyword == "this" then
-			-- Check that this is a method
-			if containingSignature.modifier ~= "method" then
-				Report.THIS_USED_OUTSIDE_METHOD {
-					location = pExpression.location,
-				}
-			end
-
-			-- Annotated the variable with the current location
-			local thisV = table.with(environment.thisVariable, "location", pExpression.location)
-
-			return buildBlock {}, {thisV}
-		elseif pExpression.keyword == "unit" then
-			local variable = generateVariable("unit", UNIT_TYPE, pExpression.location)
-			local execution = {
-				localSt(variable),
-				{
-					tag = "unit",
-					destination = variable,
-					returns = "no",
-				}
-			}
-			return buildBlock(execution), freeze {variable}
-		elseif pExpression.keyword == "return" then
-			local returns = environment.containingSignature.returnTypes
-
-			if #returns ~= 1 then
-				Report.WRONG_VALUE_COUNT {
-					purpose = "`return` expression",
-					expectedCount = 1,
-					givenCount = #returns,
-					location = pExpression.location,
-				}
-			elseif not environment.returnOuts then
-				Report.RETURN_USED_IN_IMPLEMENTATION {location = pExpression.location}
-			end
-			assert(#returns == #environment.returnOuts)
-
-			return buildBlock {}, freeze(environment.returnOuts)
-		end
-		error("TODO: keyword `" .. pExpression.keyword .. "`")
-	elseif pExpression.tag == "field" then
-		local baseEvaluation, bases = compileExpression(pExpression.base, scope, environment)
-		if #bases ~= 1 then
-			Report.WRONG_VALUE_COUNT {
-				purpose = "base of a `." .. pExpression.field .. "` field access",
-				givenCount = #bases,
-				expectedCount = 1,
-				location = pExpression.location,
+		-- Check that the number of type arguments is correct
+		if #arguments ~= #definition.definition.generics.parameters then
+			Report.WRONG_ARITY {
+				name = definition.fullName,
+				definitionLocation = definition.definition.location,
+				expectedArity = #definition.definition.generics.parameters,
+				givenArity = #arguments,
+				location = ast.location,
 			}
 		end
 
-		local base = bases[1]
-		if base.type.tag ~= "concrete-type+" then
-			Report.TYPE_MUST_BE_CLASS {
-				purpose = "base of `." .. pExpression.field .. "` field access",
-				givenType = showType(base.type),
-				location = pExpression.location,
-			}
-		end
-
-		local substituter = getSubstituterFromConcreteType(base.type, allDefinitions)
-		local definition = definitionFromType(base.type, allDefinitions)
-		if definition.tag == "class" then
-			-- Class field access
-			local field = table.findwith(definition.fields, "name", pExpression.field)
-			if not field then
-				Report.NO_SUCH_FIELD {
-					container = showType(base.type),
-					name = pExpression.field,
-					location = pExpression.location,
-				}
+		if context.checkConstraints then
+			-- Check that the arguments meet the requirements imposed by the
+			-- container
+			local argumentMap = {}
+			for i, name in ipairs(definition.genericConstraintMap.order) do
+				assert(arguments[i])
+				argumentMap[name] = arguments[i]
 			end
 
-			-- TODO: verify that access is to the current class
-
-			local result = generateVariable("field", substituter(field.type), pExpression.location)
-			local accessStatement = {
-				tag = "field",
-				name = pExpression.field,
-				base = base,
-				destination = result,
-				returns = "no",
-				fieldDefinition = field,
-			}
-
-			local block = buildBlock {
-				baseEvaluation,
-				localSt(result),
-				accessStatement,
-			}
-			return block, freeze {result}
-		elseif definition.tag == "union" then
-			-- Union variant access
-			local field = table.findwith(definition.fields, "name", pExpression.field)
-			if not field then
-				Report.NO_SUCH_VARIANT {
-					container = definition.name,
-					name = pExpression.field,
-					location = pExpression.location,
-				}
-			end
-
-			local result = generateVariable(
-				"variant",
-				substituter(field.type),
-				pExpression.location
-			)
-			local access = {
-				tag = "variant",
-				variant = pExpression.field,
-				base = base,
-				destination = result,
-				returns = "no",
-				variantDefinition = field,
-			}
-
-			-- Assert that the union variable comes from a closed set
-			local assumeUnion = closedUnionAssumption(definition, base)
-
-			local isVar = generateVariable("variantis", BOOLEAN_TYPE, pExpression.location)
-			local isStatement = {
-				tag = "isa",
-				base = base,
-				destination = isVar,
-				variant = pExpression.field,
-				returns = "no",
-			}
-			local verify = {
-				tag = "verify",
-				variable = isVar,
-				checkLocation = pExpression.location,
-				conditionLocation = pExpression.location,
-				reason = "base is a `" .. pExpression.field .. "`",
-				returns = "no",
-			}
-
-			local block = buildBlock {
-				baseEvaluation,
-				buildProof(buildBlock {
-					assumeUnion,
-					localSt(isVar),
-					isStatement,
-					verify,
-				}),
-				localSt(result),
-				access,
-			}
-
-			return block, freeze {result}
-		else
-			Report.TYPE_MUST_BE_CLASS {
-				purpose = "base of the `." .. pExpression.field .. "` field access",
-				givenType = showType(base.type),
-				location = pExpression.location,
-			}
-		end
-	elseif pExpression.tag == "binary" then
-		-- Compile the two operands
-		local leftEvaluation, leftOut = compileExpression(pExpression.left, scope, environment)
-		local rightEvaluation, rightOut = compileExpression(pExpression.right, scope, environment)
-
-		if not isExprPure(pExpression.left) and not isExprPure(pExpression.right) then
-			Report.EVALUATION_ORDER {
-				location = pExpression.location,
-			}
-		end
-
-		-- Verify there is one value on each side
-		if #leftOut ~= 1 then
-			Report.WRONG_VALUE_COUNT {
-				purpose = "the left operand of `" .. pExpression.operator .. "`",
-				expectedCount = 1,
-				givenCount = #leftOut,
-				location = pExpression.left.location,
-			}
-		elseif #rightOut ~= 1 then
-			Report.WRONG_VALUE_COUNT {
-				purpose = "the right operand of `" .. pExpression.operator .. "`",
-				expectedCount = 1,
-				givenCount = #rightOut,
-				location = pExpression.right.location,
-			}
-		end
-
-		local left, right = leftOut[1], rightOut[1]
-
-		-- Handle special operators
-		if pExpression.operator == "==" then
-			-- Check that the values are of the same type
-			if not areTypesEqual(left.type, right.type) then
-				Report.EQ_TYPE_MISMATCH {
-					leftType = showType(left.type),
-					rightType = showType(right.type),
-					location = pExpression.location,
-				}
-			end
-		end
-
-		-- Check if the operator is known
-		if not table.haskey(OPERATOR_ALIAS, pExpression.operator) then
-			return Report.UNKNOWN_OPERATOR_USED {
-				operator = pExpression.operator,
-				location = pExpression.location,
-			}
-		end
-
-		local operatorAsMethodName = OPERATOR_ALIAS[pExpression.operator]
-
-		-- Rewrite the operations as a method call
-		local callEvaluation, callOut = compileMethod(
-			left,
-			{right},
-			operatorAsMethodName,
-			false,
-			pExpression.location,
-			environment
-		)
-		return buildBlock {leftEvaluation, rightEvaluation, callEvaluation}, callOut
-	elseif pExpression.tag == "isa" then
-		local baseEvaluation, baseOut = compileExpression(pExpression.base, scope, environment)
-		if #baseOut ~= 1 then
-			Report.WRONG_VALUE_COUNT {
-				purpose = "`is " .. pExpression.variant .. "` expression",
-				expectedCount = 1,
-				givenCount = #baseOut,
-				location = pExpression.location,
-			}
-		end
-		local base = baseOut[1]
-		local baseDefinition = definitionFromType(base.type, allDefinitions)
-		if baseDefinition.tag ~= "union" then
-			Report.TYPE_MUST_BE_UNION {
-				purpose = "base of a `is " .. pExpression.variant .. "` expression",
-				givenType = showType(base.type),
-				location = pExpression.location,
-			}
-		end
-
-		local result = generateVariable("isa", BOOLEAN_TYPE, pExpression.location)
-
-		local isA = freeze {
-			tag = "isa",
-			destination = result,
-			base = base,
-			variant = pExpression.variant,
-			returns = "no",
-		}
-
-		-- Check that a variant of this name exists for this union type
-		local found = false
-		for _, field in ipairs(baseDefinition.fields) do
-			if field.name == pExpression.variant then
-				found = true
-			end
-		end
-
-		if not found then
-			Report.NO_SUCH_VARIANT {
-				container = showType(base.type),
-				name = pExpression.variant,
-				location = pExpression.location,
-			}
-		end
-
-		local isUnion = buildProof(closedUnionAssumption(baseDefinition, base))
-
-		return buildBlock {baseEvaluation, isUnion, localSt(result), isA}, freeze {result}
-	elseif pExpression.tag == "forall-expr" then
-		-- TODO: check that this is in a ghost context
-		if not environment.verification then
-			Report.QUANTIFIER_USED_IN_IMPLEMENTATION {
-				quantifier = "forall",
-				location = pExpression.location,
-			}
-		end
-
-		local scopeCopy = {}
-
-		-- Check that the name is fresh
-		for _, frame in ipairs(scope) do
-			if frame[pExpression.variable.name] then
-				Report.VARIABLE_DEFINED_TWICE {
-					name = pExpression.variable.name,
-					first = frame[pExpression.variable.name].location,
-					second = pExpression.variable.location,
-				}
-			end
-			local frameCopy = {}
-			for key, value in pairs(frame) do
-				frameCopy[key] = value
-			end
-			table.insert(scopeCopy, frameCopy)
-		end
-
-		-- RETURNS StatementIR, VariableIR (how to execute for this target, and
-		-- what the boolean truth result was for this instantiation)
-		local function instantiate(target)
-			table.insert(scopeCopy, {[pExpression.variable.name] = target})
-			local code, predicates = compileExpression(
-				pExpression.predicate,
-				scopeCopy,
-				environment
-			)
-
-			local instantiatedResult = generateVariable(
-				"forall_result_" .. pExpression.variable.name,
-				BOOLEAN_TYPE,
-				pExpression.location
-			)
-
-			-- Check types
-			checkSingleBoolean(predicates, "forall predicate")
-
-			-- Move the result into the instantiated result
-			local move = freeze {
-				tag = "assign",
-				destination = instantiatedResult,
-				source = predicates[1],
-				returns = "no",
-			}
-			code = buildBlock {code, move}
-
-			if pExpression.when then
-				local whenEval, whenVars = compileExpression(
-					pExpression.when,
-					scopeCopy,
-					environment
-				)
-
-				checkSingleBoolean(whenVars, "forall when")
-
-				-- Assume the when is true inside the if guard
-				local assumePredicate = freeze {
-					tag = "assume",
-					variable = whenVars[1],
-					location = whenVars[1].location,
-					returns = "no",
-				}
-
-				-- The result is true when the guard is false (vacuously)
-				local vacuous = freeze {
-					tag = "boolean",
-					boolean = true,
-					destination = instantiatedResult,
-					returns = "no",
-				}
-
-				-- Guard the execution in an if
-				local ifSt = freeze {
-					tag = "if",
-					condition = whenVars[1],
-					bodyThen = buildBlock {assumePredicate, code},
-					bodyElse = vacuous,
-					returns = "no",
-				}
-
-				code = buildBlock {whenEval, ifSt}
-			end
-
-			-- Close the variable's scope
-			table.remove(scopeCopy)
-
-			return buildBlock {localSt(instantiatedResult), code}, instantiatedResult
-		end
-
-		-- Generate the code once to verify that it is valid
-		-- (In particular, that preconditions hold!)
-		-- Bring the variable into scope
-		local variable1 = generateVariable(
-			pExpression.variable.name,
-			resolveType(pExpression.variable.type),
-			pExpression.variable.location
-		)
-		local testInstantiation = instantiate(variable1)
-
-		local result = generateVariable(
-			"forall_" .. pExpression.variable.name,
-			BOOLEAN_TYPE,
-			pExpression.location
-		)
-
-		local forall = freeze {
-			tag = "forall",
-			destination = result,
-			instantiate = instantiate,
-			quantified = variable1.type,
-			location = pExpression.location,
-			returns = "no",
-
-			-- XXX: Use a monotonic counter
-			unique = tostring(math.random()),
-		}
-		assertis(forall, "ForallSt")
-
-		if not isExprPure(pExpression.predicate) then
-			Report.BANG_NOT_ALLOWED {
-				context = "forall predicate",
-				location = pExpression.location,
-			}
-		elseif pExpression.when and not isExprPure(pExpression.when) then
-			Report.BANG_NOT_ALLOWED {
-				context = "forall when",
-				location = pExpression.location,
-			}
-		end
-
-		local out = buildBlock {
-			localSt(variable1),
-			testInstantiation,
-			localSt(result),
-			forall,
-		}
-
-		return out, freeze {result}
-	end
-
-	error("unknown expression tag")
-end
-
--- RETURNS the type of an instance of the given class/union:
--- Specifically, the returned type is the type of `this` in methods of that 
--- class/union
-local function typeFromDefinition(definition)
-	assertis(definition, choiceType("ClassIR", "UnionIR"))
-
-	return freeze {
-		tag = "concrete-type+",
-		name = definition.name,
-		arguments = table.map(
-			function(p)
-				return freeze {
-					tag = "generic+",
-					name = p.name,
-					location = definition.location,
-				}
-			end,
-			definition.generics
-		),
-		location = definition.location,
-	}
-end
-
--- RETURNS a type-resolving function (Parsed Type => Type+) that also validates
--- everything it receives
-local function makeTypeResolver(containingSignature, generics, allDefinitions)
-	assertis(containingSignature, "Signature")
-	assertis(generics, listType "any")
-	assertis(allDefinitions, listType "Definition")
-
-	-- RETURNS a (verified) Type+
-	return function(parsedType)
-		local typeScope = generics
-		local outType = containingSignature.resolveType(parsedType, typeScope)
-		verifyTypeValid(outType, generics, allDefinitions)
-		return outType
-	end
-end
-
---------------------------------------------------------------------------------
-
--- RETURNS a map from full name to AST Definition
-local function sourcesToASTDefinitionMap(sources)
-	local definitionSourceByFullName = {}
-	for _, source in ipairs(sources) do
-		local package = source.package
-		assertis(package, "string")
-
-		-- Record the definition of all types in this package
-		for _, definition in ipairs(source.definitions) do
-			local fullName = package .. ":" .. definition.name
-
-			-- Check that this type is not defined twice
-			local previousDefinition = definitionSourceByFullName[fullName]
-			if previousDefinition then
-				Report.TYPE_DEFINED_TWICE(previousDefinition, definition)
-			end
-
-			definitionSourceByFullName[fullName] = definition
-		end
-	end
-	return definitionSourceByFullName
-end
-
--- RETURNS a list of all Definitions
-local function getAllDefinitionsFromSources(sources)
-	-- Get a listing of all declared types
-	local definitionSourceByFullName = sourcesToASTDefinitionMap(sources)
-
-	local allDefinitions = {}
-	for _, source in ipairs(sources) do
-		local package = source.package
-
-		-- A bare `typename` should resolve to the type with name `typename`
-		-- in package `packageScopeMap[typename].package`
-		local packageScopeMap = {}
-		local function defineLocalType(name, package, location)
-			if packageScopeMap[name] then
-				Report.TYPE_BROUGHT_INTO_SCOPE_TWICE {
-					name = name,
-					firstLocation = packageScopeMap[name].location,
-					secondLocation = location,
-				}
-			end
-			packageScopeMap[name] = {
-				package = package,
-				location = location,
-			}
-		end
-
-		-- Only types in this set can be legally referred to
-		local packageIsInScope = {
-			[package] = true,
-		}
-
-		-- Bring each imported type/package into scope
-		for _, import in ipairs(source.imports) do
-			if import.class then
-				-- Check that the type exists
-				local importedFullName = import.package .. ":" .. import.class
-				if not definitionSourceByFullName[importedFullName] then
-					Report.UNKNOWN_TYPE_IMPORTED {
-						location = import.location,
-						name = importedFullName,
-					}
-				end
-
-				defineLocalType(import.class, import.package, import.location)
-			else
-				-- Importing an entire package
-				packageIsInScope[import.package] = true
-			end
-		end
-
-		-- Bring each defined type into scope
-		for _, definition in ipairs(source.definitions) do
-			local location = definition.location
-			defineLocalType(definition.name, source.package, location)
-		end
-
-		assertis(packageIsInScope, mapType("string", constantType(true)))
-
-		-- RETURNS a Type+ with a fully-qualified name
-		local function resolveType(t, typeScope)
-			assertis(typeScope, listType(recordType {name = "string"}))
-
-			if t.tag == "concrete-type" then
-				-- Search for the type in `type`
-				local package = t.package
-				if not package then
-					package = packageScopeMap[t.base]
-					if not package then
-						Report.UNKNOWN_LOCAL_TYPE_USED {
-							name = t.base,
-							location = t.location,
-						}
-					end
-					package = package.package
-				end
-				assertis(package, "string")
-				if not packageIsInScope[package] then
-					Report.UNKNOWN_PACKAGE_USED {
-						package = package,
-						location = t.location,
-					}
-				end
-
-				local fullName = package .. ":" .. t.base
-				local definition = definitionSourceByFullName[fullName]
-				if not definition then
-					Report.UNKNOWN_TYPE_USED {
-						name = fullName,
-						location = t.location,
-					}
-				elseif definition.tag == "interface-definition" then
-					Report.INTERFACE_USED_AS_VALUE {
-						interface = fullName,
-						location = t.location,
-					}
-				end
-
-				if #t.arguments ~= #definition.generics.parameters then
-					Report.WRONG_ARITY {
-						name = fullName,
-						givenArity = #t.arguments,
-						expectedArity = #definition.generics.parameters,
-						location = t.location,
-						definitionLocation = definition.location,
-					}
-				end
-
-				return freeze {
-					tag = "concrete-type+",
-					name = fullName,
-					arguments = table.map(resolveType, t.arguments, typeScope),
-					location = t.location,
-				}
-			elseif t.tag == "generic" then
-				-- Search for the name in `typeScope`
-				if not table.findwith(typeScope, "name", t.name) then
-					Report.UNKNOWN_GENERIC_USED(t)
-				end
-
-				return freeze {
-					tag = "generic+",
-					name = t.name,
-					location = t.location,
-				}
-			elseif t.tag == "type-keyword" then
-				return freeze {
-					tag = "keyword-type+",
-					name = t.name,
-					location = t.location,
-				}
-			elseif t.tag == "keyword-generic" then
-				assert(t.name == "Self")
-				return freeze {
-					tag = "self-type+",
-					location = t.location,
-				}
-			end
-			error("unhandled ast type tag `" .. t.tag .. "`")
-		end
-
-		-- RETURNS an InterfaceType+ (with a fully qualified name)
-		local function resolveInterface(t, typeScope)
-			assertis(t, recordType {
-				tag = constantType "concrete-type",
-				arguments = "object",
-				location = "Location",
-				base = "string",
-			})
-			assertis(typeScope, listType(recordType {name = "string"}))
-
-			-- Get the appropriate package for this type
-			local package = t.package
-			if not package then
-				package = packageScopeMap[t.base]
-				if not package then
-					Report.UNKNOWN_LOCAL_TYPE_USED {
-						name = t.base,
-						location = t.location,
-					}
-				end
-				package = package.package
-			end
-			assertis(package, "string")
-			if not packageIsInScope[package] then
-				Report.UNKNOWN_PACKAGE_USED {
-					package = package,
-					location = t.location,
-				}
-			end
-
-			local fullName = package .. ":" .. t.base
-			local definition = definitionSourceByFullName[fullName]
-			if not definition then
-				Report.UNKNOWN_TYPE_USED {
-					name = fullName,
-					location = t.location,
-				}
-			elseif definition.tag ~= "interface-definition" then
-				Report.CONSTRAINTS_MUST_BE_INTERFACES {
-					is = definition.tag,
-					typeShown = fullName,
-					location = t.location,
-				}
-			end
-
-			-- Check arity
-			if #t.arguments ~= #definition.generics.parameters then
-				Report.WRONG_ARITY {
-					name = definition.name,
-					givenArity = #t.arguments,
-					expectedArity = #definition.generics,
-					location = t.location,
-					definitionLocation = definition.location,
-				}
-			end
-
-			return {
-				tag = "interface-type",
-				name = fullName,
-				arguments = table.map(resolveType, t.arguments, typeScope),
-				location = t.location,
-			}
-		end
-
-		-- RETURNS a Signature
-		local function compiledSignature(signature, scope, foreign)
-			--assertis(scope, listType("TypeParameterIR"))
-			assertis(foreign, "boolean")
-
-			return freeze {
-				foreign = foreign,
-				modifier = signature.modifier.keyword,
-				memberName = signature.name,
-				returnTypes = freeze(table.map(resolveType, signature.returnTypes, scope)),
-				parameters = freeze(table.map(
-					function(p)
-						return freeze {
-							name = p.name,
-							type = resolveType(p.type, scope),
-							location = p.location,
-							description = false,
-						}
-					end,
-					signature.parameters
-				)),
-				location = signature.location,
-				bang = signature.bang,
-				ensuresAST = signature.ensures,
-				requiresAST = signature.requires,
-				scope = scope,
-
-				-- TODO: total boolean functions might have this computed:
-				logic = false,
-
-				-- TODO: total functions might have this computed:
-				eval = false,
-			}
-		end
-
-		-- RETURNS a [TypeParameterIR]
-		local function compiledGenerics(generics)
-			local parametersOut = {}
-			local map = {}
-			for _, parameterAST in ipairs(generics.parameters) do
-				local parameter = {
-					name = parameterAST,
-					constraints = {},
-					location = generics.location,
-				}
-				table.insert(parametersOut, parameter)
-
-				-- Check for duplicates
-				if map[parameter.name] then
-					Report.GENERIC_DEFINED_TWICE {
-						name = parameter.name,
-						firstLocation = generics.location,
-						secondLocation = generics.location,
-					}
-				end
-				map[parameter.name] = parameter
-			end
-
-			-- Create a type-scope
-			local typeScope = table.map(
-				function(x)
-					return {name = x}
-				end,
-				generics.parameters
-			)
-
-			-- Associate each constraint with a generic parameter
-			for _, constraintAST in ipairs(generics.constraints) do
-				local constraint = resolveInterface(constraintAST.constraint, typeScope)
-
-				-- Check that the named parameter exists
-				local parameter = map[constraintAST.parameter]
-				if not parameter then
-					Report.UNKNOWN_GENERIC_USED(constraintAST.parameter)
-				end
-
-				-- Add this constraint to the associated generic parameter
-				table.insert(parameter.constraints, {
-					interface = constraint,
-					location = constraintAST.location,
-				})
-			end
-
-			return freeze(parametersOut)
-		end
-
-		-- RETURNS a class+/union+
-		local function compiledStruct(definition, tag)
-			assertis(tag, "string")
-
-			-- name, fields, generics, implements, signatures
-
-			-- Create the full-name of the package
-			local structName = package .. ":" .. definition.name
-
-			-- Compile the set of generics introduced by this class
-			local generics = compiledGenerics(definition.generics)
-
-			local memberLocationMap = {}
-
-			-- Compile the set of fields this class has
-			local fields = {}
-			for _, field in ipairs(definition.fields) do
-				-- Check for duplicate members
-				if memberLocationMap[field.name] then
-					Report.MEMBER_DEFINED_TWICE {
-						name = field.name,
-						firstLocation = memberLocationMap[field.name],
-						secondLocation = field.location,
-					}
-				end
-				memberLocationMap[field.name] = field.location
-
-				table.insert(fields, freeze {
-					name = field.name,
-					type = resolveType(field.type, generics),
-					location = field.location,
-					description = false,
-				})
-			end
-
-			-- Collect the list of methods/statics this class provides
-			local signatures = {}
-			for _, method in ipairs(definition.methods) do
-				-- Check for duplicate members
-				local name = method.signature.name
-				if memberLocationMap[name] then
-					Report.MEMBER_DEFINED_TWICE {
-						name = name,
-						firstLocation = memberLocationMap[name],
-						secondLocation = method.location,
-					}
-				end
-				memberLocationMap[name] = method.location
-
-				local signature = compiledSignature(method.signature, generics, method.foreign)
-				signature = table.with(signature, "body", method.body)
-				signature = table.with(signature, "resolveType", resolveType)
-				signature = table.with(signature, "resolveInterface", resolveInterface)
-				signature = table.with(
-					signature,
-					"longName",
-					structName .. ":" .. signature.memberName
-				)
-				table.insert(signatures, signature)
-			end
-
-			-- Compile the set of interfaces this class claims to implement
-			local implements = table.map(resolveInterface, definition.implements, generics)
-
-			-- Create a set of constraints
-			local constraints = {}
-			for gi, generic in ipairs(generics) do
-				for ci, constraint in ipairs(generic.constraints) do
-					constraints["#" .. gi .. "_" .. ci] = constraint.interface
-				end
-			end
-
-			assertis(fields, listType "VariableIR")
-			assertis(signatures, listType "Signature")
-
-			return freeze {
-				tag = tag,
-				name = structName,
-				generics = generics,
-				fields = fields,
-				signatures = signatures,
-				implements = implements,
-				constraints = constraints,
-				location = definition.location,
-			}
-		end
-
-		local function compiledInterface(definition)
-			-- Create the fully qualified name
-			local fullName = package .. ":" .. definition.name
-
-			-- Create the generics
-			local generics = compiledGenerics(definition.generics)
-
-			local signatures = table.map(
-				function(raw)
-					local compiled = compiledSignature(raw, generics, false)
-					return table.with(compiled, "longName", fullName .. ":" .. compiled.memberName)
-				end,
-				definition.signatures
-			)
-
-			assertis(signatures, listType "Signature")
-
-			return freeze {
-				tag = "interface",
-				name = fullName,
-				generics = generics,
-				signatures = signatures,
-				location = definition.location,
-			}
-		end
-
-		-- Create an IR representation of each definition
-		for _, definition in ipairs(source.definitions) do
-			if definition.tag == "class-definition" then
-				local compiled = compiledStruct(definition, "class")
-				assertis(compiled, "ClassIR")
-
-				table.insert(allDefinitions, compiled)
-			elseif definition.tag == "interface-definition" then
-				local compiled = compiledInterface(definition)
-				assertis(compiled, "InterfaceIR")
-
-				table.insert(allDefinitions, compiled)
-			elseif definition.tag == "union-definition" then
-				local compiled = compiledStruct(definition, "union")
-				assertis(compiled, "UnionIR")
-
-				table.insert(allDefinitions, compiled)
-			else
-				error("unknown definition tag `" .. definition.tag .. "`")
-			end
-		end
-	end
-
-	return allDefinitions
-end
-
--- RETURNS a FunctionIR
-local function compileFunctionFromStruct(definition, containingSignature, allDefinitions)
-	assertis(definition, choiceType("ClassIR", "UnionIR"))
-	assertis(containingSignature, "Signature")
-	assertis(allDefinitions, listType "Definition")
-
-	local containerType = typeFromDefinition(definition)
-
-	local thisVariable = false
-	if containingSignature.modifier == "method" then
-		thisVariable = freeze {
-			name = "this",
-			type = containerType,
-			location = UNKNOWN_LOCATION,
-			description = "this",
-		}
-	end
-	local resolveType = makeTypeResolver(
-		containingSignature,
-		definition.generics,
-		allDefinitions
-	)
-
-	local environment = freeze {
-		resolveType = resolveType,
-		containerType = containerType,
-		containingSignature = containingSignature,
-		allDefinitions = allDefinitions,
-		thisVariable = thisVariable,
-		returnOuts = false,
-		ignoreEnsures = {},
-		verification = false,
-	}
-
-	local compileBlock
-
-	-- RETURNS a StatementIR
-	local function verifyForEnsures(scope, returnOuts, location)
-		assertis(returnOuts, listType "VariableIR")
-		assertis(scope, listType(mapType("string", "VariableIR")))
-		assertis(location, "Location")
-
-		local sequence = {}
-
-		-- Check that all ensured statements are true at this point
-		for i, ensures in ipairs(containingSignature.ensuresAST) do
-			local arguments = {}
-			for _, a in ipairs(containingSignature.parameters) do
-				table.insert(arguments, getFromScope(scope, a.name))
-			end
-
-			local sub = table.with(environment, "returnOuts", returnOuts)
-
-			local context = "the " .. string.ordinal(i) .. " `ensures` condition for " .. containingSignature.longName
-			local verify = generatePreconditionVerify(
-				ensures,
-				containingSignature,
-				{arguments = arguments, this = thisVariable, container = containerType,},
-				sub,
-				context,
-				location
-			)
-
-			assertis(verify, "StatementIR")
-			table.insert(sequence, verify)
-		end
-		return buildBlock(sequence)
-	end
-
-	-- RETURNS a StatementIR
-	local function compileStatement(pStatement, scope)
-		assertis(scope, listType(mapType("string", "VariableIR")))
-
-		if pStatement.tag == "var-statement" then
-			-- Allocate space for each variable on the left hand side
-			local declarations = {}
-			for _, pVariable in ipairs(pStatement.variables) do
-				-- Verify that the variable name is not in scope
-				local previous = getFromScope(scope, pVariable.name)
-				if previous then
-					Report.VARIABLE_DEFINED_TWICE {
-						first = previous.location,
-						second = pVariable.location,
-						name = pVariable.name,
-					}
-				end
-
-				-- Add the variable to the current scope
-				local variable = {
-					name = pVariable.name,
-					type = resolveType(pVariable.type),
-					location = pVariable.location,
-					description = false,
-				}
-
-				scope[#scope][variable.name] = variable
-				table.insert(declarations, {
-					tag = "local",
-					variable = variable,
-					returns = "no",
-				})
-			end
-
-			-- Evaluate the right hand side
-			local evaluation, values = compileExpression(pStatement.value, scope, environment)
-
-			-- Check the return types match the value types
-			if #values ~= #declarations then
-				Report.VARIABLE_DEFINITION_COUNT_MISMATCH {
-					location = pStatement.location,
-					expressionLocation = pStatement.value.location,
-					variableCount = #declarations,
-					valueCount = #values,
-				}
-			end
-
-			-- Move the evaluations into the destinations
-			local moves = {}
-			for i, declaration in ipairs(declarations) do
-				local variable = declaration.variable
-				if not areTypesEqual(variable.type, values[i].type) then
-					Report.TYPES_DONT_MATCH {
-						purpose = "variable `" .. variable.name .. "`",
-						expectedType = showType(variable.type),
-						expectedLocation = variable.location,
-						givenType = showType(values[i].type),
-						location = pStatement.value.location,
-					}
-				end
-
-				table.insert(moves, {
-					tag = "assign",
-					source = values[i],
-					destination = variable,
-					returns = "no",
-				})
-			end
-
-			assertis(declarations, listType "StatementIR")
-			assertis(evaluation, "StatementIR")
-			assertis(moves, listType "StatementIR")
-
-			-- Combine the three steps into a single sequence statement
-			local sequence = table.concatted(declarations, {evaluation}, moves)
-			return buildBlock(sequence)
-		elseif pStatement.tag == "return-statement" then
-			local sources = {}
-			local evaluation = {}
-			if #pStatement.values == 1 then
-				-- A single value must have exactly the target multiplicity
-				local subEvaluation, subsources = compileExpression(
-					pStatement.values[1],
-					scope,
-					environment
-				)
-
-				if #subsources ~= #containingSignature.returnTypes then
-					Report.RETURN_COUNT_MISMATCH {
-						signatureCount = #containingSignature.returnTypes,
-						returnCount = #subsources,
-						location = pStatement.location,
-					}
-				end
-
-				table.insert(evaluation, subEvaluation)
-				sources = subsources
-			elseif #pStatement.values == 0 then
-				-- Returning no values is equivalent to returning one unit
-				local unitVariable = generateVariable(
-					"unit_return",
-					UNIT_TYPE,
-					pStatement.location
-				)
-				local execution = buildBlock {
-					localSt(unitVariable),
-					{
-						tag = "unit",
-						destination = unitVariable,
-						returns = "no",
-					}
-				}
-				table.insert(evaluation, execution)
-				table.insert(sources, unitVariable)
-			else
-				-- If multiple values are given, each must be a 1-tuple
-				for _, value in ipairs(pStatement.values) do
-					local subevaluation, subsources = compileExpression(
-						value,
-						scope,
-						environment
-					)
-					if #subsources ~= 1 then
-						Report.WRONG_VALUE_COUNT {
-							purpose = "expression in multiple-value return statement",
-							expectedCount = 1,
-							givenCount = #subsources,
-							location = value.location,
-						}
-					end
-
-					table.insert(sources, subsources[1])
-					table.insert(evaluation, subevaluation)
-				end
-			end
-
-			-- Generate an ensures
-			table.insert(evaluation, verifyForEnsures(scope, sources, pStatement.location))
-
-			local returnSt = {
-				tag = "return",
-				sources = sources,
-				returns = "yes",
-			}
-			table.insert(evaluation, returnSt)
-
-			local fullName = containingSignature.longName
-
-			-- Check return types
-			assert(#sources == #containingSignature.returnTypes)
-			for i, source in ipairs(sources) do
-				local expected = containingSignature.returnTypes[i]
-				if not areTypesEqual(source.type, expected) then
-					Report.TYPES_DONT_MATCH {
-						purpose = string.ordinal(i) .. " return value of " .. fullName,
-						expectedType = showType(expected),
-						givenType = showType(source.type),
-						expectedLocation = expected.location,
-						location = source.location,
-					}
-				end
-			end
-
-			return buildBlock(evaluation)
-		elseif pStatement.tag == "do-statement" then
-			local evaluation, out = compileExpression(pStatement.expression, scope, environment)
-			assert(#out ~= 0)
-			if #out > 1 then
-				Report.WRONG_VALUE_COUNT {
-					purpose = "do-statement expression",
-					expectedCount = 1,
-					givenCount = #out,
-					location = pStatement.location,
-				}
-			elseif not areTypesEqual(out[1].type, UNIT_TYPE) then
-				Report.EXPECTED_DIFFERENT_TYPE {
-					purpose = "do-statement expression",
-					expectedType = "Unit",
-					givenType = showType(out[1].type),
-					location = pStatement.expression.location,
-				}
-			end
-
-			return evaluation
-		elseif pStatement.tag == "if-statement" then
-			local conditionEvaluation, conditionOut = compileExpression(
-				pStatement.condition,
-				scope,
-				environment
-			)
-			assert(#conditionOut ~= 0)
-			checkSingleBoolean(
-				conditionOut,
-				"if-statement condition",
-				pStatement.condition.location
-			)
-
-			-- Builds the else-if-chain IR instructions.
-			-- The index is the index of the first else-if clause to include.
-			-- RETURNS an IRStatement that holds the compiled tail of the else.
-			local function compileElseChain(i)
-				if i > #pStatement.elseifs then
-					if pStatement["else"] then
-						local blockIR = compileBlock(pStatement["else"].body, scope)
-						assertis(blockIR, "StatementIR")
-						return blockIR
-					else
-						return buildBlock({})
-					end
-				end
-				local elseIfConditionEvaluation, elseIfConditionOut = compileExpression(
-					pStatement.elseifs[i].condition,
-					scope,
-					environment
-				)
-				assert(#elseIfConditionOut ~= 0)
-				checkSingleBoolean(elseIfConditionOut, "else-if-statement condition")
-
-				local bodyThen = compileBlock(pStatement.elseifs[i].body, scope)
-				local bodyElse = compileElseChain(i + 1)
-				local ifSt = freeze {
-					tag = "if",
-					returns = unclear(bodyThen.returns, bodyElse.returns),
-					condition = elseIfConditionOut[1],
-					bodyThen = bodyThen,
-					bodyElse = bodyElse,
-				}
-				assertis(elseIfConditionEvaluation, "StatementIR")
-				assertis(ifSt, "StatementIR")
-				return buildBlock({elseIfConditionEvaluation, ifSt})
-			end
-
-			local bodyThen = compileBlock(pStatement.body, scope)
-			local bodyElse = compileElseChain(1)
-
-			local ifSt = freeze {
-				tag = "if",
-				returns = unclear(bodyThen.returns, bodyElse.returns),
-				condition = conditionOut[1],
-				bodyThen = bodyThen,
-				bodyElse = bodyElse,
-			}
-
-			assertis(conditionEvaluation, "StatementIR")
-			assertis(ifSt, "StatementIR")
-			return buildBlock({conditionEvaluation, ifSt})
-		elseif pStatement.tag == "match-statement" then
-			-- Evaluate the base expression
-			local baseEvaluation, baseOuts = compileExpression(
-				pStatement.base,
-				scope,
-				environment
-			)
-			if #baseOuts ~= 1 then
-				Report.WRONG_VALUE_COUNT {
-					purpose = "match-statement expression",
-					expectedCount = 1,
-					givenCount = #baseOuts,
-					location = pStatement.base.location,
-				}
-			end
-
-			local base = baseOuts[1]
-			assertis(base, "VariableIR")
-
-			-- Check that the base is a union
-			if base.type.tag ~= "concrete-type+" then
-				Report.TYPE_MUST_BE_UNION {
-					purpose = "expression in match-statement",
-					givenType = showType(base.type),
-					location = pStatement.base.location,
-				}
-			end
-			local definition = definitionFromType(base.type, allDefinitions)
-			if definition.tag ~= "union" then
-				Report.TYPE_MUST_BE_UNION {
-					purpose = "expression in match-statement",
-					givenType = showType(base.type),
-					location = pStatement.base.location,
-				}
-			end
-			assertis(definition, "UnionIR")
-
-			-- Check that the fields exist and are distinct
-			local unionSubstituter = getSubstituterFromConcreteType(base.type, allDefinitions)
-			local cases = {}
-			for _, case in ipairs(pStatement.cases) do
-				-- Create a subscope
-				table.insert(scope, {})
-				local sequence = {}
-
-				-- Verify that the variable name is not in scope
-				local previous = getFromScope(scope, case.head.variable)
-				if previous then
-					Report.VARIABLE_DEFINED_TWICE {
-						first = previous.location,
-						second = case.head.location,
-						name = case.head.variable,
-					}
-				end
-
-				-- Get the field
-				local field = table.findwith(definition.fields, "name", case.head.variant)
-				if not field then
-					Report.NO_SUCH_VARIANT {
-						container = showType(base.type),
-						name = case.head.variable,
-						location = case.head.location,
-					}
-				end
-				local previous = table.findwith(cases, "variant", field.name)
-				if previous then
-					Report.VARIANT_USED_TWICE {
-						variant = field.name,
-						firstLocation = previous.location,
-						secondLocation = case.head.location,
-					}
-				end
-
-				-- Add the variable to the current scope
-				local variable = {
-					name = case.head.variable,
-					type = unionSubstituter(field.type),
-					location = case.head.location,
-					description = false,
-				}
-
-				scope[#scope][variable.name] = variable
-				table.insert(sequence, {
-					tag = "local",
-					variable = variable,
-					returns = "no",
-				})
-
-				table.insert(sequence, {
-					tag = "variant",
-					variant = case.head.variant,
-					base = base,
-					destination = variable,
-					returns = "no",
-					variantDefinition = field,
-				})
-
-				local sub = compileBlock(case.body, scope)
-				table.insert(sequence, sub)
-
-				table.remove(scope)
-				table.insert(cases, freeze {
-					variant = field.name,
-					location = case.head.location,
-					statement = buildBlock(sequence),
-				})
-			end
-
-			-- Sort cases by the field order
-			table.sort(cases, function(a, b)
-				local va = table.findwith(definition.fields, "name", a.variant)
-				local vb = table.findwith(definition.fields, "name", b.variant)
-				local ia = table.indexof(definition.fields, va)
-				local ib = table.indexof(definition.fields, vb)
-				return ia < ib
-			end)
-
-			-- Check exhaustivity
-			local unhandledVariants = {}
-			for _, field in ipairs(definition.fields) do
-				if not table.findwith(cases, "variant", field.name) then
-					table.insert(unhandledVariants, field.name)
-				end
-			end
-
-			local verification
-
-			-- Check for inexhaustivity
-			if #unhandledVariants ~= 0 then
-				local seq = {
-					closedUnionAssumption(definition, base),
-				}
-
-				for _, variant in ipairs(unhandledVariants) do
-					local isBad = generateVariable(
-						"isBad_" .. variant,
-						BOOLEAN_TYPE,
-						pStatement.location
-					)
-					table.insert(seq, localSt(isBad))
-					table.insert(seq, {
-						tag = "isa",
-						base = base,
-						destination = isBad,
-						variant = variant,
-						returns = "no",
-					})
-
-					local isNotBadSt, isNotBad = irMethod(
-						pStatement.location,
-						NOT_SIGNATURE,
-						isBad,
-						{}
-					)
-					table.insert(seq, isNotBadSt)
-
-					table.insert(seq, {
-						tag = "verify",
-						variable = isNotBad,
-						checkLocation = pStatement.location,
-						conditionLocation = pStatement.location,
-						reason = "exhaustivity of match",
-						returns = "no",
+			for i, argument in ipairs(arguments) do
+				-- Gather which constraints are imposed on this argument by
+				-- the container
+				local requirements = {}
+				for _, requirement in ipairs(definition.genericConstraintMap.map[definition.genericConstraintMap.order[i]]) do
+					table.insert(requirements, {
+						constraint = substituteGenerics(requirement.constraint, argumentMap),
+						location = requirement.location,
 					})
 				end
-				verification = buildProof(buildBlock(seq))
-			else
-				verification = buildProof(closedUnionAssumption(definition, base))
-			end
 
-			-- Determine if this match returns or not
-			local noCount, yesCount = 0, 0
-			for _, case in ipairs(cases) do
-				if case.statement.returns == "yes" then
-					yesCount = yesCount + 1
-				elseif case.statement.returns == "no" then
-					noCount = noCount + 1
-				else
-					assert(case.statement.returns == "maybe")
+				-- Gather which constraints are supplied by this argument
+				local present
+				if argument.tag == "self-type" then
+					present = {context.selfAllowed}
+				elseif argument.tag == "generic-type" then
+					present = table.map(table.getter "constraint", context.generics.map[argument.name])
+					assert(present)
+				elseif argument.tag == "keyword-type" then
+					-- TODO: Can keyword types implement interfaces?
+					present = {}
+				elseif argument.tag == "compound-type" then
+					-- Get their implements claims and substitute using
+					-- arguments
+					present = {}
+					local argumentDefinition = definitionMap[argument.packageName][argument.definitionName]
+					local substitutionMap = {}
+					for i, n in ipairs(argumentDefinition.genericConstraintMap.order) do
+						assert(argument.arguments[i])
+						substitutionMap[n] = argument.arguments[i]
+					end
+					for _, implement in ipairs(argumentDefinition.implements) do
+						table.insert(present, substituteGenerics(implement, substitutionMap))
+					end
+				end
+
+				-- Check each argument for satisfaction
+				for _, requirement in ipairs(requirements) do
+					-- Search for a matching constraint
+					local satisfied = false
+					for _, constraint in ipairs(present) do
+						satisfied = satisfied or constraintSatisfiedBy(requirement.constraint, constraint)
+					end
+
+					if not satisfied then
+						Report.TYPE_MUST_IMPLEMENT_CONSTRAINT {
+							container = definition.fullName,
+							nth = i,
+							constraint = showConstraintKind(requirement.constraint),
+							cause = requirement.location,
+							type = showTypeKind(argument),
+							location = ast.arguments[i].location,
+						}
+					end
 				end
 			end
-			local returns
-			if noCount == #cases then
-				returns = "no"
-			elseif yesCount == #cases then
-				returns = "yes"
-			else
-				returns = "maybe"
-			end
-
-			local match = freeze {
-				tag = "match",
-				base = base,
-				cases = cases,
-				returns = returns,
-			}
-			return buildBlock {baseEvaluation, verification, match}
-		elseif pStatement.tag == "assign-statement" then
-			local out = {}
-
-			-- Evaluate the right-hand-side
-			local valueEvaluation, valueOut = compileExpression(
-				pStatement.value,
-				scope,
-				environment
-			)
-			if #valueOut ~= #pStatement.variables then
-				Report.WRONG_VALUE_COUNT {
-					purpose = "assignment statement",
-					expectedCount = #pStatement.variables,
-					givenCount = #valueOut,
-					location = pStatement.value.location,
-				}
-			end
-			table.insert(out, valueEvaluation)
-
-			-- Check the left hand side
-			for i, pVariable in ipairs(pStatement.variables) do
-				assertis(pVariable, "string")
-				local variable = getFromScope(scope, pVariable)
-				if not variable then
-					Report.NO_SUCH_VARIABLE {
-						name = pVariable,
-						location = pStatement.location,
-					}
-				elseif not areTypesEqual(valueOut[i].type, variable.type) then
-					Report.TYPES_DONT_MATCH {
-						purpose = string.ordinal(i) .. " value in the assignment statement",
-						expectedType = showType(variable.type),
-						expectedLocation = variable.location,
-						givenType = showType(valueOut[i].type),
-					}
-				end
-				table.insert(out, freeze {
-					tag = "assign",
-					source = valueOut[i],
-					destination = variable,
-					returns = "no",
-				})
-			end
-
-			return buildBlock(out)
-		elseif pStatement.tag == "assert-statement" then
-			-- Evaluate the right-hand-side
-			assert(environment.verification == false)
-			local valueEvaluation, valueOut = compileExpression(
-				pStatement.expression,
-				scope,
-				table.with(environment, "verification", true)
-			)
-			if #valueOut ~= 1 then
-				Report.WRONG_VALUE_COUNT {
-					purpose = "assert statement",
-					expectedCount = 1,
-					givenCount = #valueOut,
-					location = pStatement.expression.location,
-				}
-			elseif not areTypesEqual(valueOut[1].type, BOOLEAN_TYPE) then
-				Report.TYPES_DONT_MATCH {
-					purpose = "expression in assert statement",
-					expectedType = "Boolean",
-					expectedLocation = pStatement.expression.location,
-					location = pStatement.expression.location,
-					givenType = showType(valueOut[1].type),
-				}
-			end
-
-			if not isExprPure(pStatement.expression) then
-				Report.BANG_NOT_ALLOWED {
-					context = "assert",
-					location = pStatement.location,
-				}
-			end
-
-			local verify = {
-				tag = "verify",
-				variable = valueOut[1],
-				checkLocation = pStatement.location,
-				conditionLocation = pStatement.location,
-				reason = "the asserted condition",
-				returns = "no",
-			}
-			assertis(verify, "VerifySt")
-
-			local assume = {
-				tag = "assume",
-				variable = valueOut[1],
-				returns = "no",
-				location = pStatement.location,
-			}
-			assertis(assume, "AssumeSt")
-
-			return buildProof(buildBlock {
-				valueEvaluation,
-				verify,
-				assume,
-			})
 		end
-		error("TODO: compileStatement")
-	end
 
-	-- RETURNS a BlockSt
-	compileBlock = function(pBlock, scope)
-		assertis(scope, listType(mapType("string", "VariableIR")))
-
-		-- Open a new scope
-		table.insert(scope, {})
-
-		local statements = {}
-		local returned = "no"
-		for i, pStatement in ipairs(pBlock.statements) do
-			-- This statement is unreachable, because the previous
-			-- always returns
-			if returned == "yes" then
-				Report.UNREACHABLE_STATEMENT {
-					cause = statements[i - 1].location,
-					reason = "always returns",
-					unreachable = pStatement.location,
-				}
-			end
-
-			local statement = compileStatement(pStatement, scope)
-			assertis(statement, "StatementIR")
-
-			if statement.returns == "yes" then
-				returned = "yes"
-			elseif statement.returns == "maybe" then
-				returned = "maybe"
-			end
-			table.insert(statements, statement)
+		-- Determine if this a ConstraintKind or a TypeKind based on the tag of
+		-- the definition
+		local tag, role
+		if definition.definition.tag == "interface-definition" then
+			tag = "interface-constraint"
+			role = "constraint"
+		else
+			tag = "compound-type"
+			role = "type"
 		end
-		assertis(statements, listType "StatementIR")
 
-		-- Close the current scope
-		table.remove(scope)
-
-		return freeze {
-			tag = "block",
-			statements = statements,
-			returns = returned,
-			location = pBlock.location,
+		return {
+			tag = tag,
+			role = role,
+			packageName = packageName,
+			definitionName = definitionName,
+			arguments = arguments,
 		}
 	end
 
-	-- Collect static functions' type parameters from the containing class
-	local generics = {}
-	if containingSignature.modifier == "static" then
-		generics = definition.generics
-	end
-
-	-- Create the initial scope with the function's parameters
-	local functionScope = {{}}
-	for _, parameter in ipairs(containingSignature.parameters) do
-		functionScope[1][parameter.name] = parameter
-	end
-
-	-- Initialize a "this" variable
-	local initialization = buildBlock {}
-	if containingSignature.modifier == "method" then
-		initialization = buildBlock {
-			localSt(thisVariable),
-			{
-				tag = "this",
-				destination = thisVariable,
-				returns = "no",
-			},
-		}
-	end
-
-	-- Create assumptions for all of the hypotheses in `requires` clauses
-	local assumptions = {}
-	for _, requires in ipairs(containingSignature.requiresAST) do
-		assertis(environment.containerType, "Type+")
-		table.insert(assumptions, generatePostconditionAssume(
-			requires,
-			containingSignature,
-			{this = thisVariable, arguments = containingSignature.parameters},
-			environment,
-			false
-		))
-	end
-
-	local body = false
-	if not containingSignature.foreign then
-		body = buildBlock {
-			initialization,
-			buildBlock(assumptions),
-			compileBlock(containingSignature.body, functionScope)
-		}
-		assertis(body, "StatementIR")
-		if body.returns ~= "yes" then
-			-- An implicit return of unit must be added
-			local returns = {}
-			for _, returnType in ipairs(containingSignature.returnTypes) do
-				table.insert(returns, showType(returnType))
-			end
-			returns = table.concat(returns, ", ")
-
-			if returns ~= "Unit" then
-				-- But only for unit functions
-				Report.FUNCTION_DOESNT_RETURN {
-					name = containingSignature.longName,
-					modifier = containingSignature.modifier,
-					location = containingSignature.body.location,
-					returns = returns,
-				}
-			end
-
-			-- Returning no values is equivalent to returning one unit
-			local unitVariable = generateVariable(
-				"unit_return",
-				UNIT_TYPE,
-				containingSignature.body.location
-			)
-			unitVariable = table.with(unitVariable, "description", "unit")
-			local returnSt = {
-				tag = "unit",
-				destination = unitVariable,
-				returns = "no",
-			}
-
-			-- Check post conditions
-			body = buildBlock {
-				body,
-				localSt(unitVariable),
-				verifyForEnsures(
-					functionScope,
-					{unitVariable},
-					containingSignature.body.location
-				),
-				returnSt
-			}
-		end
-	end
-
-	return freeze {
-		name = containingSignature.memberName,
-		definitionName = definition.name,
-
-		-- Function's generics exclude those on the `this` instance
-		generics = generics,
-
-		parameters = containingSignature.parameters,
-		returnTypes = containingSignature.returnTypes,
-
-		body = body,
-		signature = containingSignature,
-	}
+	return resolver
 end
 
 -- RETURNS a Semantics, an IR description of the program
 local function semanticsSmol(sources, main)
 	assertis(main, "string")
 
-	-- (1) Resolve the set of types and the set of packages that have been
-	-- defined, and then fully qualify all local type names
-	local allDefinitions = getAllDefinitionsFromSources(sources)
+	-- Process package scopes
+	local definitionMap = {}
+	for _, source in ipairs(sources) do
+		-- Create package if it does not already exist
+		-- Packages need not be unique
+		local packageName = source.package.name
+		definitionMap[packageName] = definitionMap[packageName] or {}
 
-	allDefinitions = freeze(allDefinitions)
-	assertis(allDefinitions, listType "Definition")
-
-	-- (3) Verify and record all interfaces implementation
-
-	-- Verify that `class` actually implements each interface that it claims to
-	-- RETURNS nothing
-	local function checkStructImplementsClaims(class)
-		for _, int in ipairs(class.implements) do
-			local interfaceName = int.name
-			local interface = table.findwith(allDefinitions, "name", interfaceName)
-			assert(interface and interface.tag == "interface")
-			assert(#int.arguments == #interface.generics)
-
-			-- Instantiate each of the interface's type parameters with the
-			-- argument specified in the "implements"
-			local classType = typeFromDefinition(class, allDefinitions)
-			local subs = getSubstituterFromInterface(int, classType, allDefinitions)
-
-			-- Check that each signature matches
-			for _, iSignature in ipairs(interface.signatures) do
-				-- Search for a method/static with the same name, if any
-				local cSignature = table.findwith(
-					class.signatures,
-					"memberName",
-					iSignature.memberName
-				)
-				if not cSignature then
-					Report.INTERFACE_REQUIRES_MEMBER {
-						class = class.name,
-						interface = showInterfaceType(int),
-						implementsLocation = int.location,
-						memberLocation = iSignature.location,
-						memberName = iSignature.name,
+		-- Get a set of imported names
+		local importsByName = {}
+		for _, import in ipairs(source.imports) do
+			if import.definitionName then
+				if importsByName[import.definitionName] then
+					Report.NAME_IMPORTED_TWICE {
+						name = import.definitionName,
+						firstLocation = importsByName[import.definitionName].location,
+						secondLocation = import.location,
 					}
 				end
-
-				-- Check that the modifier matches
-				if cSignature.modifier ~= iSignature.modifier then
-					Report.INTERFACE_REQUIRES_MODIFIER {
-						name = cSignature.name,
-						class = class.name,
-						interface = showInterfaceType(int),
-						classModifier = cSignature.modifier,
-						interfaceModifier = iSignature.modifier,
-						classLocation = cSignature.location,
-						interfaceLocation = iSignature.location,
-					}
-				end
-
-				-- Check that the parameters match
-				if #cSignature.parameters ~= #iSignature.parameters then
-					Report.INTERFACE_PARAMETER_COUNT_MISMATCH {
-						class = class.name,
-						classLocation = cSignature.location,
-						classCount = #cSignature.parameters,
-						interface = showInterfaceType(int),
-						interfaceLocation = iSignature.location,
-						interfaceCount = #iSignature.parameters,
-					}
-				end
-
-				for k, iParameter in ipairs(iSignature.parameters) do
-					local iType = subs(iParameter.type)
-					local cParameter = cSignature.parameters[k]
-					local cType = cParameter.type
-					if not areTypesEqual(iType, cType) then
-						Report.INTERFACE_PARAMETER_TYPE_MISMATCH {
-							class = class.name,
-							classLocation = cParameter.location,
-							classType = showType(cType),
-							interface = showInterfaceType(int),
-							interfaceLocation = iParameter.location,
-							interfaceType = showType(iType),
-							index = k,
-						}
-					end
-				end
-
-				-- Check that the return types match
-				if #cSignature.returnTypes ~= #iSignature.returnTypes then
-					Report.INTERFACE_RETURN_COUNT_MISMATCH {
-						class = class.name,
-						interface = showInterfaceType(int),
-						classLocation = cSignature.location,
-						interfaceLocation = iSignature.location,
-						classCount = #cSignature.returnTypes,
-						interfaceCount = #iSignature.returnTypes,
-						member = cSignature.name,
-					}
-				end
-
-				for k, cType in ipairs(cSignature.returnTypes) do
-					local iType = subs(iSignature.returnTypes[k])
-					if not areTypesEqual(iType, cType) then
-						Report.INTERFACE_RETURN_TYPE_MISMATCH {
-							class = class.name,
-							interface = showInterfaceType(int),
-							classLocation = cType.location,
-							interfaceLocation = iType.location,
-							classType = showType(cType),
-							interfaceType = showType(iType),
-							index = k,
-							member = cSignature.memberName,
-						}
-					end
-				end
-			end
-		end
-	end
-
-	-- Verify all implementation claims
-	for _, class in ipairs(allDefinitions) do
-		if class.tag == "class" or class.tag == "union" then
-			checkStructImplementsClaims(class)
-		end
-	end
-
-	-- (4) Verify all existing Type+'s (from headers) are OKAY
-	for _, definition in ipairs(allDefinitions) do
-		assertis(definition, "Definition")
-
-		-- Verify that the generic constraints are valid
-		for _, parameter in ipairs(definition.generics) do
-			for _, constraint in ipairs(parameter.constraints) do
-				verifyInterfaceValid(constraint.interface, definition.generics, allDefinitions)
+				importsByName[import.definitionName] = import
 			end
 		end
 
-		if definition.tag == "class" then
-			-- Verify each field
-			for _, field in ipairs(definition.fields) do
-				verifyTypeValid(field.type, definition.generics, allDefinitions)
-			end
-
-			-- Verify each implements
-			for _, implements in ipairs(definition.implements) do
-				verifyInterfaceValid(implements, definition.generics, allDefinitions)
-			end
-
-			-- Verify each signature
-			for _, signature in ipairs(definition.signatures) do
-				-- Verify each signature parameter type
-				for _, parameter in ipairs(signature.parameters) do
-					verifyTypeValid(parameter.type, definition.generics, allDefinitions)
-				end
-
-				-- Verify each signature return type
-				for _, returnType in ipairs(signature.returnTypes) do
-					verifyTypeValid(returnType, definition.generics, allDefinitions)
-				end
-
-				-- Verify the signature's body later
-			end
-		elseif definition.tag == "union" then
-			-- Verify each field
-			for _, field in ipairs(definition.fields) do
-				verifyTypeValid(field.type, definition.generics, allDefinitions)
-			end
-
-			-- Verify each implements
-			for _, implements in ipairs(definition.implements) do
-				verifyInterfaceValid(implements, definition.generics, allDefinitions)
-			end
-
-			-- Verify each signature
-			for _, signature in ipairs(definition.signatures) do
-				-- Verify each signature parameter type
-				for _, parameter in ipairs(signature.parameters) do
-					verifyTypeValid(parameter.type, definition.generics, allDefinitions)
-				end
-
-				-- Verify each signature return type
-				for _, returnType in ipairs(signature.returnTypes) do
-					verifyTypeValid(returnType, definition.generics, allDefinitions)
-				end
-			end
-		elseif definition.tag == "interface" then
-			-- Verify each signature
-			for _, signature in ipairs(definition.signatures) do
-				-- Verify each signature parameter type
-				for _, parameter in ipairs(signature.parameters) do
-					verifyTypeValid(parameter.type, definition.generics, allDefinitions)
-				end
-
-				-- Verify each signature return type
-				for _, returnType in ipairs(signature.returnTypes) do
-					verifyTypeValid(returnType, definition.generics, allDefinitions)
-				end
-			end
-		else
-			error("unknown Definition tag `" .. definition.tag .. "`")
-		end
-	end
-
-	-- (4.5) Verify the type of all ensures/requires
-	for _, definition in ipairs(allDefinitions) do
-		if definition.tag == "class" or definition.tag == "union" then
-			for _, signature in ipairs(definition.signatures) do
-				-- Verify the type of the signature's ensures and requires
-				local scope = {{}}
-				for _, parameter in ipairs(signature.parameters) do
-					scope[1][parameter.name] = parameter
-				end
-
-				local containerType = typeFromDefinition(definition)
-				local thisVariable = false
-				if signature.modifier == "method" then
-					thisVariable = freeze {
-						location = UNKNOWN_LOCATION,
-						name = "this",
-						type = containerType,
-						description = "this",
-					}
-				end
-
-				local returnOuts = {}
-				for i, returned in ipairs(signature.returnTypes) do
-					table.insert(returnOuts, {
-						location = UNKNOWN_LOCATION,
-						name = "_r" .. i,
-						type = returned,
-						description = "return#" .. i,
-					})
-				end
-
-				local verificationEnvironment = freeze {
-					resolveType = makeTypeResolver(signature, definition.generics, allDefinitions),
-					containerType = containerType,
-					containingSignature = signature,
-					allDefinitions = allDefinitions,
-					thisVariable = thisVariable,
-					returnOuts = returnOuts,
-					ignoreEnsures = {},
-					verification = true,
+		-- Get each definition in this source
+		for _, definition in ipairs(source.definitions) do
+			local previousDefinition = definitionMap[packageName][definition.name]
+			if previousDefinition then
+				-- Definition of same name already exists
+				Report.DEFINITION_DEFINED_TWICE {
+					fullName = previousDefinition.fullName,
+					firstLocation = previousDefinition.definition.location,
+					secondLocation = definition.location,
 				}
+			elseif importsByName[definition.name] then
+				-- Import of same short name already exists
+				Report.DEFINITION_DEFINED_TWICE {
+					fullName = definition.name,
+					firstLocation = importsByName[definition.name].location,
+					secondLocation = definition.location,
+				}
+			end
 
-				local function checkVerificationBoolean(e, purpose)
-					assertis(purpose, "string")
+			-- Record the existence of this definition
+			definitionMap[packageName][definition.name] = {
+				packageName = packageName,
+				fullName = packageName .. ":" .. definition.name,
+				importsByName = importsByName,
+				source = source,
+				definition = definition,
+			}
+		end
+	end
 
-					local _, outs = compileExpression(e, scope, verificationEnvironment)
-					checkSingleBoolean(outs, purpose, e.location)
+	-- Annotate each definition with its resolver
+	for packageName, package in pairs(definitionMap) do
+		for definitionName, definition in pairs(package) do
+			definition.resolver = makeDefinitionASTResolver(definition, definitionMap)
+			local arguments = {}
+			for _, parameter in ipairs(definition.definition.generics.parameters) do
+				table.insert(arguments, {
+					tag = "generic-type",
+					role = "type",
+					name = parameter.name,
+				})
+			end
+
+			-- Get the tag and role based on the definition tag
+			local tag, role
+			if definition.definition.tag == "interface-definition" then
+				tag = "interface-constraint"
+				role = "constraint"
+			else
+				tag = "compound-type"
+				role = "type"
+			end
+
+			-- Mark the definition with the kind that it represents
+			-- This may need to be "instantiated" if the definition is
+			-- parametric
+			definition.kind = {
+				tag = tag,
+				role = role,
+				arguments = arguments,
+				packageName = packageName,
+				definitionName = definitionName,
+			}
+		end
+	end
+
+	-- Get the generic requirements for all definintions
+	for _, package in pairs(definitionMap) do
+		for _, definition in pairs(package) do
+			-- Check that generic parameters are not repeated
+			local constraintMap = {}
+			local genericLocationMap = {}
+			local parameterNames = {}
+			for _, parameterAST in ipairs(definition.definition.generics.parameters) do
+				if genericLocationMap[parameterAST.name] then
+					Report.GENERIC_DEFINED_TWICE {
+						name = parameterAST.name,
+						firstLocation = genericLocationMap[parameterAST.name],
+						secondLocation = parameterAST.location,
+					}
+				end
+				genericLocationMap[parameterAST.name] = parameterAST.location
+				constraintMap[parameterAST.name] = {}
+				table.insert(parameterNames, parameterAST.name)
+			end
+			
+			assertis(definition.kind, "Kind")
+
+			local context = {
+				-- #Self is only allowed in Interface definitions
+				selfAllowed = definition.definition.tag == "interface-definition" and definition.kind,
+
+				-- We do not yet know which generics are in scope with which
+				-- constraints
+				generics = genericLocationMap,
+				checkConstraints = false,
+			}
+
+			-- Read the constraints, suppressing errors regarding no constraints
+			-- Note: We MUST check them again afterwards
+			for _, constraintAST in ipairs(definition.definition.generics.constraints) do
+				local concerning = constraintAST.parameter.name
+
+				-- Process the constraint, checking that it is a ConstraintKind
+				-- and not a TypeKind
+				local constraint = definition.resolver(constraintAST.constraint, context)
+				if constraint.role ~= "constraint" then
+					Report.CONSTRAINTS_MUST_BE_INTERFACES {
+						is = "type parameter constraint",
+						typeShown = showTypeKind(constraint),
+						location = constraintAST.location,
+					}
 				end
 
-				-- Check that each requires has type Boolean
-				for _, requires in ipairs(signature.requiresAST) do
-					checkVerificationBoolean(requires.condition, "requires condition")
-					for _, when in ipairs(requires.whens) do
-						checkVerificationBoolean(when, "requires when condition")
-						if not isExprPure(when) then
-							Report.BANG_NOT_ALLOWED {
-								context = "requires-when",
-								location = when.location,
-							}
-						end
-					end
-					if not isExprPure(requires.condition) then
-						Report.BANG_NOT_ALLOWED {
-							context = "requires",
-							location = requires.condition.location,
-						}
-					end
+				table.insert(constraintMap[concerning], {
+					constraint = constraint,
+					location = constraintAST.location,
+				})
+			end
+
+			-- Record, for future checking, the constraints that each type
+			-- parameter claims to implement
+			definition.genericConstraintMap = {
+				order = parameterNames,
+				map = constraintMap,
+				locations = genericLocationMap,
+			}
+
+			-- Read the implements claims, suppressing errors regarding no
+			-- constraints
+			-- NOTE: We MUST check them again afterwards
+			local claims = {}
+			for _, claimAST in ipairs(definition.definition.implements) do
+				local claim = definition.resolver(claimAST, context)
+				if claim.role ~= "constraint" then
+					Report.CONSTRAINTS_MUST_BE_INTERFACES {
+						is = "implements claim",
+						typeShown = showTypeKind(claim),
+						location = claimAST.location,
+					}
 				end
 
-				-- Check that each ensures has type Boolean
-				for _, ensures in ipairs(signature.ensuresAST) do
-					checkVerificationBoolean(ensures.condition, "ensures condition")
-					for _, when in ipairs(ensures.whens) do
-						checkVerificationBoolean(when, "ensures when condition")
-						if not isExprPure(when) then
-							Report.BANG_NOT_ALLOWED {
-								context = "ensures-when",
-								location = when.location,
-							}
-						end
-					end
-					if not isExprPure(ensures.condition) then
-						Report.BANG_NOT_ALLOWED {
-							context = "ensures",
-							location = ensures.condition.location,
-						}
-					end
-				end
+				table.insert(claims, claim)
+			end
+			
+			assertis(claims, listType "ConstraintKind")
+			definition.implements = claims
+		end
+	end
+
+	-- Check that the bits concerning constraint definitions (implements and
+	-- generic constraints) themselves don't violate any constraints
+	for _, package in pairs(definitionMap) do
+		for _, definition in pairs(package) do
+			local context = {
+				-- #Self is only allowed in Interface definitions
+				selfAllowed = definition.definition.tag == "interface-definition" and definition.kind,
+
+				-- We do not yet know which generics are in scope with which
+				-- constraints
+				generics = definition.genericConstraintMap,
+				checkConstraints = true,
+			}
+
+			-- Check the well-formedness of each implements claim
+			for _, claimAST in ipairs(definition.definition.implements) do
+				definition.resolver(claimAST, context)
+			end
+
+			-- Check the well-formedness of each interface constraint
+			for _, constraint in ipairs(definition.definition.generics.constraints) do
+				definition.resolver(constraint.constraint, context)
 			end
 		end
 	end
 
-	-- (5) Compile all code bodies
-	local compounds = {}
-	local interfaces = {}
-	local functions = {}
-
-	-- Scan the definitions for all function bodies
-	for _, definition in ipairs(allDefinitions) do
-		if definition.tag == "class" or definition.tag == "union" then
-			for _, signature in ipairs(definition.signatures) do
-				local func = compileFunctionFromStruct(definition, signature, allDefinitions)
-				assertis(func, "FunctionIR")
-
-				table.insert(functions, func)
-			end
-			table.insert(compounds, definition)
-		elseif definition.tag == "interface" then
-			table.insert(interfaces, definition)
-		else
-			error("unknown definition tag `" .. definition.tag .. "`")
-		end
-	end
-
-	assertis(functions, listType "FunctionIR")
-
-	-- Check that the main class exists
-	if main == "skip" then
-		main = false
-	else
-		local mainClass = table.findwith(compounds, "name", main)
-		if not mainClass or mainClass.tag ~= "class" then
-			Report.NO_MAIN {
-				name = main,
-			}
-		end
-		local mainStatic = table.findwith(mainClass.signatures, "memberName", "main")
-		if not mainStatic or mainStatic.modifier ~= "static" then
-			Report.NO_MAIN_STATIC {
-				name = main,
-			}
-		elseif #mainStatic.parameters ~= 0 then
-			Report.NO_MAIN_STATIC {
-				name = main,
-			}
-		elseif #mainClass.generics ~= 0 then
-			Report.MAIN_MUST_NOT_BE_GENERIC {
-				name = main,
-			}
-		end
-	end
+	-- Compile the remainder
+	
 
 	return freeze {
-		builtins = BUILTIN_DEFINITIONS,
+		builtins = common.BUILTIN_DEFINITIONS,
 		compounds = compounds,
 		interfaces = interfaces,
 		functions = functions,

--- a/src/semantics.lua
+++ b/src/semantics.lua
@@ -2566,7 +2566,7 @@ local function semanticsSmol(sources, main)
 						Report.MEMBER_DEFINED_TWICE {
 							name = signature.memberName,
 							firstLocation = previous.definitionLocation,
-							secondLocation = signature.definitionLocation,
+							secondLocation = methodAST.signature.location,
 						}
 					end
 

--- a/src/semantics.lua
+++ b/src/semantics.lua
@@ -525,7 +525,7 @@ local function checkTypes(p)
 		Report.WRONG_VALUE_COUNT {
 			expectedCount = #p.expected,
 			givenCount = #p.given,
-			purpose = purpose,
+			purpose = p.purpose,
 			givenLocation = p.givenLocation,
 			expectedLocation = p.expectedLocation,
 		}
@@ -1040,7 +1040,6 @@ local function compileExpression(expressionAST, scope, context)
 			}
 		}
 
-		local providedAt = {}
 		local fieldAssignment = {}
 		local initializationLocation = {}
 		local impure = false

--- a/src/syntax.lua
+++ b/src/syntax.lua
@@ -200,7 +200,6 @@ local parsers = {
 	-- Represents a class
 	["class-definition"] = parser.composite {
 		tag = "class-definition",
-		{"foreign", parser.query "`foreign`?"},
 		{"_", K_CLASS},
 		{"name", T_TYPENAME, "a type name"},
 		{

--- a/src/syntax.lua
+++ b/src/syntax.lua
@@ -595,7 +595,7 @@ local parsers = {
 		tag = "new-expression",
 		{"_", K_NEW},
 		{"_", K_ROUND_OPEN, "`(` after `new`"},
-		{"arguments", parser.query "named-argument,0+"},
+		{"fields", parser.query "named-argument,0+"},
 		{"_", K_ROUND_CLOSE, "`)` to end `new` expression"},
 	},
 

--- a/src/syntax.lua
+++ b/src/syntax.lua
@@ -673,14 +673,18 @@ local parsers = {
 		{"_", K_ROUND_OPEN, "`(` after `forall`"},
 		{"variable", parser.named "variable", "variable after `forall (`"},
 		{"_", K_ROUND_CLOSE, "`)` after variable"},
-		{"predicate", parser.named "expression", "predicate expression"},
+		{"condition", parser.named "expression", "predicate expression"},
 		{
-			"when",
-			parser.optional(parser.composite {
-				tag = "forall-when",
-				{"_", K_WHEN},
-				{"#e", parser.named "expression", "expression"},
-			}),
+			"whens",
+			parserOtherwise(
+				parser.optional(parser.composite {
+					tag = "forall-when",
+					location = false,
+					{"_", K_WHEN},
+					{"#when", parser.query "expression,1+", "an expression"},
+				}),
+				{}
+			),
 		}
 	},
 

--- a/src/syntax.lua
+++ b/src/syntax.lua
@@ -631,7 +631,7 @@ local parsers = {
 	["method-access"] = parser.composite {
 		tag = "method-call",
 		{"_", K_DOT},
-		{"methodName", T_IDENTIFIER, "a method/field name"},
+		{"funcName", T_IDENTIFIER, "a method/field name"},
 
 		-- What follows is optional, since a field access is also possible
 		{"bang", parser.optional(K_BANG)},

--- a/src/test-unfinished/verify-all-container/test.smol
+++ b/src/test-unfinished/verify-all-container/test.smol
@@ -13,22 +13,22 @@ union Map[#K, #V | #K is core:Eq, #V is core:Eq] is core:Eq {
 	// This is because matching is (unfortunately) NOT private.
 	method eq(other Map[#K, #V]) Boolean {
 		match this {
-			case e1 empty {
+			case e1 is empty {
 				match other {
-					case e2 empty {
+					case e2 is empty {
 						return true;
 					}
-					case a2 addition {
+					case a2 is addition {
 						return false;
 					}
 				}
 			}
-			case a1 addition {
+			case a1 is addition {
 				match other {
-					case e2 empty {
+					case e2 is empty {
 						return false;
 					}
-					case a2 addition {
+					case a2 is addition {
 						return a1 == a2;
 					}
 				}
@@ -50,10 +50,10 @@ union Map[#K, #V | #K is core:Eq, #V is core:Eq] is core:Eq {
 	//when (this is addition).and((this.addition.getLeft().getLeft() == (key)).not())
 	{
 		match this {
-			case e empty {
+			case e is empty {
 				return core:Option[#V].makeNone();
 			}
-			case a addition {
+			case a is addition {
 				if a.getLeft().getLeft() == key {
 					return core:Option[#V].makeSome(a.getLeft().getRight());
 				}

--- a/src/test-unfinished/verify-sort/test.smol
+++ b/src/test-unfinished/verify-sort/test.smol
@@ -43,7 +43,7 @@ union Sort {
 	method getDomainSort() Sort
 	requires this is fn {
 		match this {
-			case fn fn {
+			case fn is fn {
 				return fn.getDomainSort();
 			}
 		}
@@ -51,7 +51,7 @@ union Sort {
 	method getRangeSort() Sort
 	requires this is fn {
 		match this {
-			case fn fn {
+			case fn is fn {
 				return fn.getRangeSort();
 			}
 		}
@@ -59,22 +59,22 @@ union Sort {
 
 	method eq(other Sort) Boolean {
 		match this {
-			case f1 fn {
+			case f1 is  {
 				match other {
-					case f2 fn {
+					case f2 is fn {
 						return f1 == f2;
 					}
-					case n2 named {
+					case n2 is named {
 						return false;
 					}
 				}
 			}
-			case n1 named {
+			case n1 is named {
 				match other {
-					case f2 fn {
+					case f2 is fn {
 						return false;
 					}
-					case n2 named {
+					case n2 is named {
 						return n1 == n2;
 					}
 				}

--- a/src/tokenization.lua
+++ b/src/tokenization.lua
@@ -79,7 +79,7 @@ local function lexSmol(source, filename)
 			"#[A-Z][A-Za-z0-9]*",
 			function(x)
 				if IS_KEYWORD[x:sub(2)] then
-					return {tag = "keyword-generic", name = "Self"}
+					return {tag = "keyword-generic", name = x:sub(2)}
 				end
 				return {tag = "generic", name = x:sub(2)}
 			end

--- a/src/types.lua
+++ b/src/types.lua
@@ -394,7 +394,7 @@ local normalizedT = {}
 
 -- ASSERTS that `value` is of the specified type `t`
 function assertis(value, t)
-	do return true end
+	--do return true end
 
 	-- TYPE_DESCRIPTION must be injective
 	-- Normalize types so that memoization works

--- a/src/types.lua
+++ b/src/types.lua
@@ -394,7 +394,7 @@ local normalizedT = {}
 
 -- ASSERTS that `value` is of the specified type `t`
 function assertis(value, t)
-	--do return true end
+	do return true end
 
 	-- TYPE_DESCRIPTION must be injective
 	-- Normalize types so that memoization works

--- a/src/verify-errors.lua
+++ b/src/verify-errors.lua
@@ -20,12 +20,12 @@ function Report.DOES_NOT_MODEL(p)
 	end
 
 	if p.conditionLocation == p.checkLocation then
-		quit("You must show that ", p.reason, " holds as defined ", p.conditionLocation, ruled)
+		quit("You must show that ", p.reason, " holds as required ", p.conditionLocation, ruled)
 	end
 	quit(
-		"You must show that ",
+		"You must show ",
 		p.reason,
-		" holds as defined ",
+		" as required ",
 		p.conditionLocation,
 		ruled,
 		"\n",

--- a/src/verify-theory.lua
+++ b/src/verify-theory.lua
@@ -104,6 +104,8 @@ fnAssertion = memoized(4, fnAssertion)
 
 --------------------------------------------------------------------------------
 
+local validateModel
+
 -- RETURNS a string
 local showSkip = {}
 local function showAssertion(assertion)
@@ -490,11 +492,37 @@ local function listToMap(list)
 	return m
 end
 
+--------------------------------------------------------------------------------
+
+-- RETURNS nothing
+-- Checks some invariants of the smol model
+function validateModel(model)
+	do
+		return
+	end
+
+	for a, c in model._eq:traverse() do
+		for _, t in c:traverse() do
+			if t.tag == "fn" then
+				local con = fnLiteralEvaluation(t, model._eq)
+				if con ~= nil then
+					if model._eq:specialsOf("literal", t):size() == 0 then
+						print("CONCERNING:", theory:canonKey(t))
+						error("Constant evaluation doesn't agree with cached literals-of")
+					end
+				end
+			end
+		end
+	end
+end
+
 -- RETURNS whether or not the given model is satisfiable in a quantifier free
 -- theory of uninterpreted functions
 -- as a part of the 'theory' interface for the SMT solver
 local function modelSatisfiable(self)
 	assertis(self, "SmolModel")
+
+	validateModel(self)
 
 	if self._contradiction then
 		return false, self._contradiction
@@ -640,7 +668,9 @@ local function recheckFunction(subassertion, eqQueue, eq, functionMap, mentionMa
 				local literal, reasons = fnLiteralEvaluation(subassertion, eq)
 				if literal ~= nil then
 					local literalExpression = constantAssertion(literal)
+					local before = theory:canonKey(literalExpression)
 					literalExpression = canon:scan(literalExpression)
+					assert(before == theory:canonKey(literalExpression))
 					eq = eq:withTryInit(literalExpression)
 					if not eq:query(literalExpression, subassertion) then
 						table.insert(eqQueue, {
@@ -669,6 +699,7 @@ end
 -- detection is fast
 local function modelAssigned(self, key, truth)
 	assertis(self, "SmolModel")
+	validateModel(self)
 
 	local eq = self._eq
 	local assertion = self._canon:scan(key)
@@ -729,6 +760,8 @@ local function modelAssigned(self, key, truth)
 		if assertion.tag == "eq" then
 			local left = self._canon:scan(assertion.left)
 			local right = self._canon:scan(assertion.right)
+			assert(theory:canonKey(left) == theory:canonKey(assertion.left))
+			assert(theory:canonKey(right) == theory:canonKey(assertion.right))
 
 			if truth then
 				-- a = b joins union find
@@ -790,8 +823,23 @@ local function modelAssigned(self, key, truth)
 				staleRep = oldRightRep
 			end
 			if staleRep then
+				-- Merge maps
+				if not mentionMap:get(newRep) then
+					mentionMap = mentionMap:with(newRep, Map.new())
+				end
 				if mentionMap:get(staleRep) then
-					for mentioner in mentionMap:get(staleRep):traverse() do
+					for mention in mentionMap:get(staleRep):traverse() do
+						assertis(mention, "Assertion")
+
+						local merged = mentionMap:get(newRep):with(mention, true)
+						mentionMap = mentionMap:with(newRep, merged)
+					end
+				end
+
+				-- Find functions that are now equal via their arguments being
+				-- equal
+				if mentionMap:get(newRep) then
+					for mentioner in mentionMap:get(newRep):traverse() do
 						eq, functionMap, mentionMap = recheckFunction(
 							mentioner,
 							eqQueue,
@@ -838,6 +886,7 @@ local function modelAssigned(self, key, truth)
 		_functionMap = functionMap,
 	}
 	assertis(out, "SmolModel")
+	validateModel(out)
 	return out
 end
 
@@ -875,6 +924,7 @@ function theory:makeEmptyModel()
 	out._eq = out._eq:withInit(aTrue):withInit(aFalse)
 
 	assertis(out, "SmolModel")
+	validateModel(out)
 	return out
 end
 

--- a/src/verify-theory.lua
+++ b/src/verify-theory.lua
@@ -241,7 +241,7 @@ local function m_scan(self, object)
 			tag = "field",
 			base = self:scan(object.base),
 			fieldName = object.fieldName,
-			definition = object.definition,
+			fieldType = object.fieldType,
 		}
 		self.relevant[shown] = real
 	elseif object.tag == "variant" then
@@ -249,7 +249,7 @@ local function m_scan(self, object)
 			tag = "variant",
 			base = self:scan(object.base),
 			variantName = object.variantName,
-			definition = object.definition,
+			variantType = object.variantType,
 		}
 		self.relevant[shown] = real
 	elseif object.tag == "gettag" then

--- a/src/verify-theory.lua
+++ b/src/verify-theory.lua
@@ -9,10 +9,7 @@ local Map = import "data/map.lua"
 local UnionFind = import "data/unionfind.lua"
 
 local common = import "common.lua"
-local showType = common.showType
-
-local BUILTIN_DEFINITIONS = common.BUILTIN_DEFINITIONS
-local BOOLEAN_DEF = table.findwith(BUILTIN_DEFINITIONS, "name", "Boolean")
+local showTypeKind = common.showTypeKind
 
 local areTypesEqual = common.areTypesEqual
 
@@ -33,7 +30,7 @@ local function notAssertion(a)
 	return freeze {
 		tag = "fn",
 		arguments = {a},
-		signature = table.findwith(BOOLEAN_DEF.signatures, "memberName", "not"),
+		signature = common.builtinDefinitions.Boolean.functionMap["not"].signature,
 		index = 1,
 	}
 end
@@ -43,7 +40,7 @@ notAssertion = memoized(1, notAssertion)
 local function eqAssertion(a, b, t)
 	assertis(a, "Assertion")
 	assertis(b, "Assertion")
-	assertis(t, "Type+")
+	assertis(t, "TypeKind")
 
 	local p = freeze {
 		tag = "eq",
@@ -156,7 +153,7 @@ local function showAssertion(assertion)
 	elseif assertion.tag == "symbol" then
 		return "(symbol " .. assertion.symbol .. ")"
 	elseif assertion.tag == "forall" then
-		return "(forall " .. showType(assertion.quantified) .. " " .. assertion.unique .. " " .. assertion.instance .. ")"
+		return "(forall " .. showTypeKind(assertion.quantified) .. " " .. assertion.unique .. " " .. assertion.instance .. ")"
 	end
 	error("unknown assertion tag `" .. assertion.tag .. "` in showAssertion")
 end
@@ -312,7 +309,7 @@ local function quantifierClauses(model, term, truth)
 			assertis(x, "Assertion")
 
 			local tx = typeOfAssertion(x)
-			assertis(tx, "Type+")
+			assertis(tx, "TypeKind")
 
 			if areTypesEqual(tx, term.quantified) then
 				table.insert(opportunities, x)

--- a/src/verify.lua
+++ b/src/verify.lua
@@ -753,7 +753,7 @@ local function verifyStatement(statement, scope, semantics)
 
 			-- Remember whether or not the condition was true when we started
 			-- evaluating it
-			local snappedCondition = addSnapshot(scope, condition, statement.base.location)
+			local snappedCondition = addSnapshot(scope, condition)
 
 			-- Add variant predicate
 			addPredicate(subscope, condition)
@@ -939,7 +939,7 @@ return function(semantics)
 	for _, c in ipairs(semantics.compounds) do
 		assertis(c, recordType {
 			tag = choiceType(constantType("union-definition"), constantType("class-definition")),
-			fieldMap = mapType("string", recordType {
+			_fieldMap = mapType("string", recordType {
 				name = "string",
 				type = "TypeKind",
 			}),
@@ -947,7 +947,8 @@ return function(semantics)
 		})
 		assertis(c.constraintArguments, listType(recordType {
 			name = "string",
-			index = "integer",
+			concerningIndex = "integer",
+			constraintListIndex = "integer",
 			constraint = "ConstraintKind",
 		}))
 	end

--- a/src/verify.lua
+++ b/src/verify.lua
@@ -689,11 +689,11 @@ local function verifyStatement(statement, scope, semantics)
 		local assertion = variantAssertion(statement)
 		assignRaw(scope, statement.destination, assertion)
 		return
-	elseif statement.tag == "int" then
+	elseif statement.tag == "int-load" then
 		-- Integer literal
 		assignRaw(scope, statement.destination, valueInt(statement.number))
 		return
-	elseif statement.tag == "string" then
+	elseif statement.tag == "string-load" then
 		-- String literal
 		assignRaw(scope, statement.destination, valueString(statement.string))
 		return

--- a/src/verify.lua
+++ b/src/verify.lua
@@ -26,7 +26,6 @@ local BOOLEAN_DEF = table.findwith(BUILTIN_DEFINITIONS, "name", "Boolean")
 local typeOfAssertion = common.typeOfAssertion
 
 local excerpt = common.excerpt
-local variableDescription = common.variableDescription
 
 local assertionExprString = common.assertionExprString
 local showType = common.showType

--- a/test.lua
+++ b/test.lua
@@ -269,6 +269,10 @@ if mode ~= "-" then
 					"-Wall",
 					"-Wextra",
 					"-Wconversion",
+
+					-- Only show one error
+					"-Wfatal-errors",
+
 					-- Disable unhelpful warnings
 					"-Wno-unused-parameter",
 					"-Wno-unused-but-set-variable",

--- a/tests-negative/scope/forall-shadows-parameter/test.smol
+++ b/tests-negative/scope/forall-shadows-parameter/test.smol
@@ -1,0 +1,11 @@
+package test;
+
+class Test {
+	static foo(n Int) Unit
+	requires forall (n Int) true {
+	}
+
+	static main() Unit {
+		
+	}
+}

--- a/tests-negative/scope/interface-bang-mismatch/test.smol
+++ b/tests-negative/scope/interface-bang-mismatch/test.smol
@@ -1,0 +1,16 @@
+package test;
+
+interface I {
+	method pure() Int;
+}
+
+class C is I {
+	method pure!() Int {
+		return 1;
+	}
+}
+
+class Test {
+	static main() Unit {
+	}
+}

--- a/tests-negative/scope/interface-cannot-new/test.smol
+++ b/tests-negative/scope/interface-cannot-new/test.smol
@@ -1,0 +1,13 @@
+package test;
+
+interface I {
+	method foo() Unit
+	ensures new().good();
+
+	method good() Boolean ensures return;
+}
+
+class Test {
+	static main() Unit {
+	}
+}

--- a/tests-negative/scope/interface-parameter-count-mismatch-more/test.smol
+++ b/tests-negative/scope/interface-parameter-count-mismatch-more/test.smol
@@ -1,0 +1,14 @@
+package test;
+
+interface I {
+	method m(a Int, b Int) Unit;
+}
+
+class C is I {
+	method m(b Int) Unit {
+	}
+}
+
+class Test {
+	static main() Unit {}
+}

--- a/tests-negative/scope/interface-parameter-type-mismatch/test.smol
+++ b/tests-negative/scope/interface-parameter-type-mismatch/test.smol
@@ -1,0 +1,15 @@
+package test;
+
+interface I {
+	method m(a Int) Int;
+}
+
+class C is I {
+	method m(b String) Int {
+		return 1;
+	}
+}
+
+class Test {
+	static main() Unit {}
+}

--- a/tests-negative/scope/interface-return-count-mismatch-less/test.smol
+++ b/tests-negative/scope/interface-return-count-mismatch-less/test.smol
@@ -1,0 +1,15 @@
+package test;
+
+interface I {
+	method m() Int;
+}
+
+class C is I {
+	method m() Int, Int {
+		return 0, 0;
+	}
+}
+
+class Test {
+	static main() Unit {}
+}

--- a/tests-negative/scope/interface-return-count-mismatch-more/test.smol
+++ b/tests-negative/scope/interface-return-count-mismatch-more/test.smol
@@ -1,0 +1,15 @@
+package test;
+
+interface I {
+	method m() Int, Int;
+}
+
+class C is I {
+	method m() Int {
+		return 0;
+	}
+}
+
+class Test {
+	static main() Unit {}
+}

--- a/tests-negative/scope/interface-return-type-mismatch/test.smol
+++ b/tests-negative/scope/interface-return-type-mismatch/test.smol
@@ -1,0 +1,15 @@
+package test;
+
+interface I {
+	method m(a Int) Int;
+}
+
+class C is I {
+	method m(b Int) String {
+		return "";
+	}
+}
+
+class Test {
+	static main() Unit {}
+}

--- a/tests-negative/scope/no-such-variant/test.smol
+++ b/tests-negative/scope/no-such-variant/test.smol
@@ -12,13 +12,13 @@ union U {
 class Test {
 	static main!() Unit {
 		match U.makeA() {
-			case x b {
+			case x is b {
 
 			}
-			case x a {
+			case x is a {
 
 			}
-			case x y {
+			case x is y {
 
 			}
 		}

--- a/tests-negative/scope/self-static/test.smol
+++ b/tests-negative/scope/self-static/test.smol
@@ -1,0 +1,10 @@
+package test;
+
+class Test {
+	static nothing() Unit {
+	}
+
+	static main() Unit {
+		do #Self.nothing();
+	}
+}

--- a/tests-negative/scope/unknown-generic-in-class-signature/test.smol
+++ b/tests-negative/scope/unknown-generic-in-class-signature/test.smol
@@ -4,9 +4,7 @@ class Test {
 	static main() Unit {
 		var x String = "foo";
 	}
-}
 
-
-interface IFace {
-	static foo() #T;
+	static bar(t #T) Unit {
+	}
 }

--- a/tests-negative/scope/unknown-generic-in-interface-signature/test.smol
+++ b/tests-negative/scope/unknown-generic-in-interface-signature/test.smol
@@ -4,7 +4,9 @@ class Test {
 	static main() Unit {
 		var x String = "foo";
 	}
+}
 
-	static bar(t #T) Unit {
-	}
+
+interface IFace {
+	static foo() #T;
 }

--- a/tests-negative/types/interface-ensures-int/test.smol
+++ b/tests-negative/types/interface-ensures-int/test.smol
@@ -1,0 +1,11 @@
+package test;
+
+interface Foo {
+	method shouldReject() Unit
+	ensures 5;
+}
+
+class Test {
+	static main() Unit {
+	}
+}

--- a/tests-negative/types/interface-requires-int/test.smol
+++ b/tests-negative/types/interface-requires-int/test.smol
@@ -1,0 +1,11 @@
+package test;
+
+interface Foo {
+	method shouldReject() Unit
+	requires 5;
+}
+
+class Test {
+	static main() Unit {
+	}
+}

--- a/tests-negative/types/match-on-class/test.smol
+++ b/tests-negative/types/match-on-class/test.smol
@@ -9,7 +9,7 @@ class C {
 class Test {
 	static main!() Unit {
 		match C.make() {
-			case x x {
+			case x is x {
 			}
 		}
 	}

--- a/tests-negative/types/match-on-type-parameter/test.smol
+++ b/tests-negative/types/match-on-type-parameter/test.smol
@@ -3,7 +3,7 @@ package test;
 class Foo[#T] {
 	static foo(t #T) Unit {
 		match t {
-			case x x {
+			case x is x {
 			}
 		}
 	}

--- a/tests-negative/types/repeat-match-variant/test.smol
+++ b/tests-negative/types/repeat-match-variant/test.smol
@@ -12,10 +12,10 @@ union U {
 class Test {
 	static main!() Unit {
 		match U.makeA() {
-			case a a {
+			case a is a {
 
 			}
-			case a a {
+			case a is a {
 
 			}
 		}

--- a/tests-negative/types/unused-interface-has-bad-type/test.smol
+++ b/tests-negative/types/unused-interface-has-bad-type/test.smol
@@ -1,0 +1,17 @@
+package test;
+import core;
+
+class F[#T | #T is core:Eq] {
+
+}
+
+interface Unused {
+	// Since Test does not implement Eq, it should not be accepted as a type
+	// parameter to F.
+	method shouldreject() F[Test];
+}
+
+class Test {
+	static main() Unit {
+	}
+}

--- a/tests-negative/verification/check-generic-requires/test.smol
+++ b/tests-negative/verification/check-generic-requires/test.smol
@@ -1,0 +1,31 @@
+package test;
+
+class B3[#T, #C | #C is ListLike[#T]] is ListLike[#T] {
+	var one #C;
+	var two #C;
+	var three #C;
+
+	method size() Int {
+		return (this.one.size() + this.two.size()) + this.three.size();
+	}
+
+	method get(n Int) #T {
+		// This should be rejected
+		return this.one.get(n);
+	}
+}
+
+interface ListLike[#T] {
+	method get(n Int) #T
+	requires 0 < n
+	requires (n < this.size()).or(n == this.size());
+
+	method size() Int;
+}
+
+class Test {
+	static main() Unit {
+
+	}
+}
+

--- a/tests-negative/verification/inexhaustive-match/test.smol
+++ b/tests-negative/verification/inexhaustive-match/test.smol
@@ -12,7 +12,7 @@ union U {
 class Test {
 	static main!() Unit {
 		match U.makeA() {
-			case x b {
+			case x is b {
 
 			}
 		}

--- a/tests-negative/verification/verify-and-after-match/test.smol
+++ b/tests-negative/verification/verify-and-after-match/test.smol
@@ -19,10 +19,10 @@ class Test {
 		var x Int = u;
 
 		match opaque {
-			case a a {
+			case a is a {
 				x = 0;
 			}
-			case b b {
+			case b is b {
 				x = 1;
 			}
 		}

--- a/tests-negative/verification/verify-inexhaustive-option-match/test.smol
+++ b/tests-negative/verification/verify-inexhaustive-option-match/test.smol
@@ -4,7 +4,7 @@ import core;
 class Test {
 	static get(option core:Option[core:WInt]) core:WInt {
 		match option {
-			case some some {
+			case some is some {
 				return some;
 			}
 		}

--- a/tests-positive/comprehensive/arraytree/test.smol
+++ b/tests-positive/comprehensive/arraytree/test.smol
@@ -1,0 +1,136 @@
+package test;
+
+class T0[#T] is ListLike[#T] {
+	method size() Int
+	ensures return == 0 {
+		return 0;
+	}
+
+	method get(n Int) #T
+	requires false {
+		assert false;
+	}
+}
+
+class T1[#T] is ListLike[#T] {
+	var one #T;
+
+	static make(v #T) T1[#T] {
+		return new(one = v);
+	}
+
+	method size() Int
+	ensures return == 1 {
+		return 1;
+	}
+
+	method get(n Int) #T {
+		return this.one;
+	}
+}
+
+class T2[#T] is ListLike[#T] {
+	var one #T;
+	var two #T;
+
+	static make(v1 #T, v2 #T) T2[#T] {
+		return new(one = v1, two = v2);
+	}
+
+	method size() Int
+	ensures return == 2 {
+		return 2;
+	}
+
+	method get(n Int) #T {
+		if (n == 1) {
+			return this.one;
+		}
+		return this.two;
+	}
+}
+
+class T3[#T] is ListLike[#T] {
+	var one #T;
+	var two #T;
+	var three #T;
+
+	static make(v1 #T, v2 #T, v3 #T) T3[#T] {
+		return new(one = v1, two = v2, three = v3);
+	}
+
+	method size() Int
+	ensures return == 3{
+		return 3;
+	}
+
+	method get(n Int) #T {
+		if (n == 1) {
+			return this.one;
+		} elseif (n == 2) {
+			return this.two;
+		}
+		return this.three;
+	}
+}
+
+union Up3[#T] is ListLike[#T] {
+	var zero T0[#T];
+	var one T1[#T];
+	var two T2[#T];
+	var three T3[#T];
+
+	method size() Int
+	ensures return == 0 when this is zero
+	ensures return == 1 when this is one
+	ensures return == 2 when this is two
+	ensures return == 3 when this is three {
+		if this is zero {
+			return 0;
+		} elseif this is one {
+			return 1;
+		} elseif this is two {
+			return 2;
+		}
+		return 3;
+	}
+
+	method get(n Int) #T
+	requires 0 < n
+	requires (n < this.size()).or(n == this.size()) {
+		if this is one {
+			return this.one.get(n);
+		} elseif this is two {
+			return this.two.get(n);
+		}
+		return this.three.get(n);
+	}
+}
+
+class B3[#T, #C | #C is ListLike[#T]] is ListLike[#T] {
+	var one #C;
+	var two #C;
+	var three #C;
+
+	method size() Int {
+		return (this.one.size() + this.two.size()) + this.three.size();
+	}
+
+	method get(n Int) #T {
+		return this.one.get(n);
+	}
+}
+
+interface ListLike[#T] {
+	method get(n Int) #T
+	requires 0 < n
+	requires (n < this.size()).or(n == this.size());
+
+	method size() Int;
+}
+
+class Test {
+	static main() Unit {
+
+	}
+}

--- a/tests-positive/comprehensive/lists/test.smol
+++ b/tests-positive/comprehensive/lists/test.smol
@@ -59,10 +59,10 @@ class List[#T] {
 	method length() Int
 	ensures (0 == return).or(0 < return) {
 		match this.inner {
-			case n nil {
+			case n is nil {
 				return 0;
 			}
-			case c cons {
+			case c is cons {
 				assert (this.rest().length() == 0).or(0 < this.rest().length());
 				assert 1 == (0 + 1);
 				assert 0 < (this.rest().length() + 1);

--- a/tests-positive/runtime/basic-match-test/test.smol
+++ b/tests-positive/runtime/basic-match-test/test.smol
@@ -18,19 +18,19 @@ union Un {
 class Test {
 	static main!() Unit {
 		match Un.makeA(7) {
-			case n a {
+			case n is a {
 				do core:Out.println!("a" ++ core:ASCII.formatInt(n));
 			}
-			case n b {
+			case n is b {
 				do core:Out.println!("b" ++ core:ASCII.formatInt(n));
 			}
 		}
 
 		match Un.makeB(9) {
-			case n a {
+			case n is a {
 				do core:Out.println!("a" ++ core:ASCII.formatInt(n));
 			}
-			case n b {
+			case n is b {
 				do core:Out.println!("b" ++ core:ASCII.formatInt(n));
 			}
 		}

--- a/tests-positive/runtime/binary-heap/test.smol
+++ b/tests-positive/runtime/binary-heap/test.smol
@@ -1,18 +1,22 @@
 package test;
 import core;
 
+class Array[#T] {
+	
+}
+
 class MinBinaryHeap[#T | #T is core:Orderable, #T is core:Showable] {
-	var sequence core:Array[#T];
+	var sequence Array[#T];
 
 	static makeEmpty() MinBinaryHeap[#T] {
-		return new(sequence = core:Array[#T].make());
+		return new(sequence = Array[#T].make());
 	}
 
-	static make(sequence core:Array[#T]) MinBinaryHeap[#T] {
+	static make(sequence Array[#T]) MinBinaryHeap[#T] {
 		return new(sequence = sequence);
 	}
 
-	static heapProperty(sequence core:Array[#T]) Boolean {
+	static heapProperty(sequence Array[#T]) Boolean {
 		return true;
 	}
 
@@ -26,7 +30,7 @@ class MinBinaryHeap[#T | #T is core:Orderable, #T is core:Showable] {
 		return (index - 1) / 2;
 	}
 
-	static bubbleUp(list core:Array[#T], index Int) core:Array[#T] {
+	static bubbleUp(list Array[#T], index Int) Array[#T] {
 		if index == 0 {
 			return list;
 		}
@@ -40,7 +44,7 @@ class MinBinaryHeap[#T | #T is core:Orderable, #T is core:Showable] {
 		return list;
 	}
 
-	static bubbleDown(list core:Array[#T], index Int) core:Array[#T] {
+	static bubbleDown(list Array[#T], index Int) Array[#T] {
 		var a Int = MinBinaryHeap[#T].zLeftChild(index);
 		var b Int = MinBinaryHeap[#T].zRightChild(index);
 		if (list.size() - 1) < a {
@@ -66,7 +70,7 @@ class MinBinaryHeap[#T | #T is core:Orderable, #T is core:Showable] {
 	}
 
 	method insert(value #T) MinBinaryHeap[#T] {
-		var modified core:Array[#T] = this.sequence.append(value);
+		var modified Array[#T] = this.sequence.append(value);
 		modified = MinBinaryHeap[#T].bubbleUp(modified, modified.size() - 1);
 		return MinBinaryHeap[#T].make(modified);
 	}

--- a/tests-positive/structure/recursive-interface-constraint/test.smol
+++ b/tests-positive/structure/recursive-interface-constraint/test.smol
@@ -1,0 +1,8 @@
+package test;
+
+interface I[#T | #T is I[#T]] {
+}
+
+class Test {
+	static main() Unit {}
+}

--- a/tests-positive/structure/static-interface-methods/test.smol
+++ b/tests-positive/structure/static-interface-methods/test.smol
@@ -1,16 +1,16 @@
 package test;
 
-interface Makeable[#T] {
+interface MakerOf[#T] {
 	static make() #T;
 }
 
-class Foo is Makeable[Foo] {
+class Foo is MakerOf[Foo] {
 	static make() Foo {
 		return new();
 	}
 }
 
-class Box[#T | #T is Makeable[#T]] is Makeable[Box[#T]] {
+class Box[#T | #T is MakerOf[#T]] is MakerOf[Box[#T]] {
 	var thing #T;
 
 	static make() Box[#T] {
@@ -20,6 +20,7 @@ class Box[#T | #T is Makeable[#T]] is Makeable[Box[#T]] {
 
 class Test {
 	static main() Unit {
+		var n Box[Foo] = Box[Foo].make();
 	}
 }
 

--- a/tests-positive/verification/assert-false-as-returns/test.smol
+++ b/tests-positive/verification/assert-false-as-returns/test.smol
@@ -1,0 +1,15 @@
+package test;
+
+class Test {
+	static f(n Int) Int
+	requires n == 3 {
+		if n == 3 {
+			return 1;
+		}
+		assert false;
+	}
+
+	static main() Unit {
+
+	}
+}

--- a/tests-positive/verification/assumes-generic-ensures/test.smol
+++ b/tests-positive/verification/assumes-generic-ensures/test.smol
@@ -1,0 +1,17 @@
+package test;
+
+interface Foo {
+	static f() Int ensures return == 7;
+}
+
+class C[#T | #T is Foo] {
+	static f() Unit {
+		assert #T.f() == 7;
+	}
+}
+
+class Test {
+	static main() Unit {
+
+	}
+}

--- a/tests-positive/verification/verify-flow-match/test.smol
+++ b/tests-positive/verification/verify-flow-match/test.smol
@@ -6,10 +6,10 @@ union U {
 
 	method foo() Unit {
 		match this {
-			case alpha alpha {
+			case alpha is alpha {
 				assert this is alpha;
 			}
-			case beta beta {
+			case beta is beta {
 				assert this is beta;
 				return beta;
 			}

--- a/tests-positive/verification/verify-or-after-match/test.smol
+++ b/tests-positive/verification/verify-or-after-match/test.smol
@@ -18,10 +18,10 @@ class Test {
 		var x Int = u;
 
 		match opaque {
-			case a a {
+			case a is a {
 				x = 0;
 			}
-			case b b {
+			case b is b {
 				x = 1;
 			}
 		}

--- a/tests-positive/verification/verify-union-isa-one-of-options/test.smol
+++ b/tests-positive/verification/verify-union-isa-one-of-options/test.smol
@@ -1,0 +1,18 @@
+package test;
+
+union Foo {
+	var a Unit;
+	var b Unit;
+
+	static make() Foo {
+		return new(a = unit);
+	}
+}
+
+class Test {
+	
+	static main() Unit {
+		var f Foo = Foo.make();
+		assert (f is a).or(f is b);
+	}
+}

--- a/tests-positive/verification/verify-when-is/test.smol
+++ b/tests-positive/verification/verify-when-is/test.smol
@@ -7,7 +7,7 @@ class Test {
 	requires option is some
 	ensures option.some == return when option is some{
 		match option {
-			case some some {
+			case some is some {
 				return some;
 			}
 		}


### PR DESCRIPTION
This PR rewrites IR generation and code generation.

I simplified the IR and syntax in a number of a places.

The only significant breaking change in this PR is modifying `match` syntax:

```
// BEFORE
case x left {

// AFTER
case x is left {
```

I fully implemented post-conditions/pre-conditions on generic calls (but do not yet check they agree with subtyping).

I added many tests.